### PR TITLE
Interpolated strings

### DIFF
--- a/Core/EVIL.Grammar/AST/Constants/StringConstant.cs
+++ b/Core/EVIL.Grammar/AST/Constants/StringConstant.cs
@@ -5,10 +5,12 @@ namespace EVIL.Grammar.AST.Constants
     public sealed class StringConstant : ConstantExpression
     {
         public string Value { get; }
+        public bool IsInterpolated { get; }
 
-        public StringConstant(string value)
+        public StringConstant(string value, bool isInterpolated)
         {
             Value = value;
+            IsInterpolated = isInterpolated;
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Expressions/BinaryExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/BinaryExpression.cs
@@ -114,7 +114,7 @@ namespace EVIL.Grammar.AST.Expressions
                 {
                     if (Type == BinaryOperationType.Add)
                     {
-                        return new StringConstant(lsc.Value + rsc.Value, lsc.IsInterpolated)
+                        return new StringConstant(lsc.Value + rsc.Value, lsc.IsInterpolated || rsc.IsInterpolated)
                             .CopyMetadata<StringConstant>(this);
                     }
                 }

--- a/Core/EVIL.Grammar/AST/Expressions/BinaryExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/BinaryExpression.cs
@@ -114,7 +114,7 @@ namespace EVIL.Grammar.AST.Expressions
                 {
                     if (Type == BinaryOperationType.Add)
                     {
-                        return new StringConstant(lsc.Value + rsc.Value)
+                        return new StringConstant(lsc.Value + rsc.Value, lsc.IsInterpolated)
                             .CopyMetadata<StringConstant>(this);
                     }
                 }
@@ -127,11 +127,11 @@ namespace EVIL.Grammar.AST.Expressions
 
                         if (amount >= str.Length)
                         {
-                            return new StringConstant(string.Empty)
+                            return new StringConstant(string.Empty, false)
                                 .CopyMetadata<StringConstant>(this);
                         }
 
-                        return new StringConstant(str.Substring(amount))
+                        return new StringConstant(str.Substring(amount), false)
                             .CopyMetadata<StringConstant>(this);
                     }
                     else if (Type == BinaryOperationType.ShiftRight)
@@ -141,11 +141,11 @@ namespace EVIL.Grammar.AST.Expressions
 
                         if (amount <= 0)
                         {
-                            return new StringConstant(string.Empty)
+                            return new StringConstant(string.Empty, false)
                                 .CopyMetadata<StringConstant>(this);
                         }
 
-                        return new StringConstant(str.Substring(0, amount))
+                        return new StringConstant(str.Substring(0, amount), false)
                             .CopyMetadata<StringConstant>(this);
                     }
                 }

--- a/Core/EVIL.Grammar/AST/Expressions/UnaryExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/UnaryExpression.cs
@@ -46,7 +46,7 @@ namespace EVIL.Grammar.AST.Expressions
                             .CopyMetadata<NumberConstant>(this);
 
                     case UnaryOperationType.ToString:
-                        return new StringConstant(numberConstant.Value.ToString(CultureInfo.InvariantCulture))
+                        return new StringConstant(numberConstant.Value.ToString(CultureInfo.InvariantCulture), false)
                             .CopyMetadata<StringConstant>(this);
                 }
             }
@@ -71,7 +71,7 @@ namespace EVIL.Grammar.AST.Expressions
                     }
 
                     case UnaryOperationType.ToString:
-                        return new StringConstant(stringConstant.Value)
+                        return new StringConstant(stringConstant.Value, stringConstant.IsInterpolated)
                             .CopyMetadata<StringConstant>(this);
                 }
             }

--- a/Core/EVIL.Grammar/EVIL.Grammar.csproj
+++ b/Core/EVIL.Grammar/EVIL.Grammar.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>11.0</LangVersion>
         
-        <Version>2.1.1</Version>
+        <Version>2.2.0</Version>
         <AssemblyName>EVIL.Grammar</AssemblyName>
         <AssemblyTitle>EVIL.Grammar</AssemblyTitle>
     </PropertyGroup>

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.ConstantExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.ConstantExpression.cs
@@ -69,11 +69,18 @@ namespace EVIL.Grammar.Parsing
                     return new BooleanConstant(false)
                         { Line = line, Column = col };
                 }
-                case TokenType.String:
+                case TokenType.PlainString:
                 {
-                    var (line, col) = Match(Token.String);
+                    var (line, col) = Match(Token.PlainString);
 
-                    return new StringConstant(token.Value)
+                    return new StringConstant(token.Value, false)
+                        { Line = line, Column = col };
+                }
+                case TokenType.InterpolatedString:
+                {
+                    var (line, col) = Match(Token.InterpolatedString);
+
+                    return new StringConstant(token.Value, true)
                         { Line = line, Column = col };
                 }
                 case TokenType.Nil:

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.IndexerExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.IndexerExpression.cs
@@ -17,7 +17,7 @@ namespace EVIL.Grammar.Parsing
                 (line, col) = Match(Token.Dot);
 
                 var identifier = Identifier();
-                indexer = new StringConstant(identifier.Name)
+                indexer = new StringConstant(identifier.Name, false)
                 {
                     Line = identifier.Line,
                     Column = identifier.Column

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.TableExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.TableExpression.cs
@@ -63,7 +63,7 @@ namespace EVIL.Grammar.Parsing
                             if (CurrentToken == Token.Colon)
                             {
                                 Match(Token.Colon);
-                                key = new StringConstant(keyIdentifier.Name)
+                                key = new StringConstant(keyIdentifier.Name, false)
                                     { Line = keyIdentifier.Line, Column = keyIdentifier.Column };
                             }
                             else

--- a/Core/EVIL.Lexical/EVIL.Lexical.csproj
+++ b/Core/EVIL.Lexical/EVIL.Lexical.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>11.0</LangVersion>
         
-        <Version>2.1.0</Version>
+        <Version>2.2.0</Version>
         <AssemblyName>EVIL.Lexical</AssemblyName>
         <AssemblyTitle>EVIL.Lexical</AssemblyTitle>
     </PropertyGroup>

--- a/Core/EVIL.Lexical/Lexer.cs
+++ b/Core/EVIL.Lexical/Lexer.cs
@@ -482,7 +482,7 @@ namespace EVIL.Lexical
             if (delimiter != '"' && delimiter != '\'')
             {
                 throw new LexerException(
-                    "Strings can only be delimiated in '' or \"\".",
+                    "Strings can only be delimited by '' or \"\".",
                     line, col
                 );
             }

--- a/Core/EVIL.Lexical/Lexer.cs
+++ b/Core/EVIL.Lexical/Lexer.cs
@@ -477,19 +477,19 @@ namespace EVIL.Lexical
             var (line, col) = (State.Line, State.Column);
 
             var str = string.Empty;
-            var encapsulator = State.Character;
+            var delimiter = State.Character;
 
-            if (encapsulator != '"' && encapsulator != '\'')
+            if (delimiter != '"' && delimiter != '\'')
             {
                 throw new LexerException(
-                    "Strings can only be encapsulated in '' or \"\".",
+                    "Strings can only be delimiated in '' or \"\".",
                     line, col
                 );
             }
 
             Advance();
 
-            while (State.Character != encapsulator)
+            while (State.Character != delimiter)
             {
                 if (State.Character == (char)0)
                     throw new LexerException("Unterminated string.", line, col);
@@ -535,6 +535,9 @@ namespace EVIL.Lexical
                         case '\\':
                             str += '\\';
                             break;
+                        case '$':
+                            str += '$';
+                            break;
                         default:
                             throw new LexerException("Unrecognized escape sequence.", State.Line, State.Column);
                     }
@@ -547,7 +550,14 @@ namespace EVIL.Lexical
                 Advance();
             }
 
-            return Token.CreateString(str);
+            if (delimiter == '\'')
+            {
+                return Token.CreatePlainString(str);
+            }
+            else // '"'
+            {
+                return Token.CreateInterpolatedString(str);
+            }
         }
 
         private char GetUnicodeSequence()

--- a/Core/EVIL.Lexical/Token.cs
+++ b/Core/EVIL.Lexical/Token.cs
@@ -21,8 +21,11 @@ namespace EVIL.Lexical
         public static Token CreateHexInteger(string value)
             => new(TokenType.HexInteger, TokenClass.Literal, value);
 
-        public static Token CreateString(string value)
-            => new(TokenType.String, TokenClass.Literal, value);
+        public static Token CreatePlainString(string value)
+            => new(TokenType.PlainString, TokenClass.Literal, value);
+
+        public static Token CreateInterpolatedString(string value)
+            => new(TokenType.InterpolatedString, TokenClass.Literal, value);
 
         public static Token CreateNumber(string value)
             => new(TokenType.Number, TokenClass.Literal, value);
@@ -183,8 +186,9 @@ namespace EVIL.Lexical
         public static readonly Token Identifier = new(TokenType.Identifier, TokenClass.Identifier, string.Empty);
         public static readonly Token Number = new(TokenType.Number, TokenClass.Literal, string.Empty);
         public static readonly Token HexInteger = new(TokenType.HexInteger, TokenClass.Literal, string.Empty);
-        public static readonly Token String = new(TokenType.String, TokenClass.Literal, string.Empty);
-
+        public static readonly Token PlainString = new(TokenType.PlainString, TokenClass.Literal, string.Empty);
+        public static readonly Token InterpolatedString = new(TokenType.InterpolatedString, TokenClass.Literal, string.Empty);
+        
         public static readonly Token EOF = new(TokenType.EOF, TokenClass.Meta, "<EOF>");
         public static readonly Token Empty = new(TokenType.Empty, TokenClass.Meta, string.Empty);
     }

--- a/Core/EVIL.Lexical/TokenType.cs
+++ b/Core/EVIL.Lexical/TokenType.cs
@@ -73,7 +73,8 @@
 
         Number,
         HexInteger,
-        String,
+        PlainString,
+        InterpolatedString,
 
         True,
         False,

--- a/Core/Tests/EVIL.CoreTests/LexerTests.cs
+++ b/Core/Tests/EVIL.CoreTests/LexerTests.cs
@@ -191,8 +191,8 @@ namespace EVIL.CoreTests
             ExpectExact(
                 (TokenType.PlainString, "single-quoted string"),
                 (TokenType.PlainString, "single-quoted string with ' escape"),
-                (TokenType.PlainString, "double quoted string"),
-                (TokenType.PlainString, "double quoted string with \" escape"),
+                (TokenType.InterpolatedString, "double quoted string"),
+                (TokenType.InterpolatedString, "double quoted string with \" escape"),
                 (TokenType.PlainString, "this is a \uABCD \x1234")
             );
 

--- a/Core/Tests/EVIL.CoreTests/LexerTests.cs
+++ b/Core/Tests/EVIL.CoreTests/LexerTests.cs
@@ -189,11 +189,11 @@ namespace EVIL.CoreTests
             );
             
             ExpectExact(
-                (TokenType.String, "single-quoted string"),
-                (TokenType.String, "single-quoted string with ' escape"),
-                (TokenType.String, "double quoted string"),
-                (TokenType.String, "double quoted string with \" escape"),
-                (TokenType.String, "this is a \uABCD \x1234")
+                (TokenType.PlainString, "single-quoted string"),
+                (TokenType.PlainString, "single-quoted string with ' escape"),
+                (TokenType.PlainString, "double quoted string"),
+                (TokenType.PlainString, "double quoted string with \" escape"),
+                (TokenType.PlainString, "this is a \uABCD \x1234")
             );
 
             Expect(EOF);

--- a/VirtualMachine/Ceres/Ceres.csproj
+++ b/VirtualMachine/Ceres/Ceres.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
     
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <AssemblyName>Ceres</AssemblyName>
     <AssemblyTitle>Ceres</AssemblyTitle>
   </PropertyGroup>

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Constant.String.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Constant.String.cs
@@ -1,17 +1,105 @@
+using System.Linq;
+using System.Text.RegularExpressions;
 using Ceres.ExecutionEngine.Diagnostics;
+using Ceres.ExecutionEngine.TypeSystem;
 using EVIL.Grammar.AST.Constants;
 
 namespace Ceres.TranslationEngine
 {
     public partial class Compiler
     {
+        private static Regex _stringSubstitutionRegex = new(@"(?<substitution>\$(?<symbol_name>[\p{L}_]([\p{L}\p{Nd}_]+)?))");
+
+        /*
+         *        
+
+
+         * 
+         */
         public override void Visit(StringConstant stringConstant)
         {
-            var id = Chunk.StringPool.FetchOrAdd(stringConstant.Value);
-            Chunk.CodeGenerator.Emit(
-                OpCode.LDSTR,
-                (int)id
-            );
+            if (stringConstant.IsInterpolated)
+            {
+                var additionCount = 0;
+                var templateString = stringConstant.Value;
+                var matches = _stringSubstitutionRegex.Matches(templateString);
+
+                if (!matches.Any())
+                {
+                    var id = Chunk.StringPool.FetchOrAdd(stringConstant.Value);
+                    Chunk.CodeGenerator.Emit(
+                        OpCode.LDSTR,
+                        (int)id
+                    );
+
+                    return;
+                }
+                
+                var endOfLastGroup = -1;
+        
+                for (var i = 0; i < matches.Count; i++)
+                {
+                    var match = matches[i];
+                    var group = match.Groups["substitution"];
+                    var symbolName = match.Groups["symbol_name"].Value;
+                    var before = "";
+                    endOfLastGroup = group.Index + group.Length;
+            
+                    if (i == 0)
+                    {
+                        before = templateString.Substring(0, group.Index);
+                    }
+                    else
+                    {
+                        var prevMatch = matches[i - 1];
+                        var prevGroup = prevMatch.Groups["substitution"];
+                        var endOfPreviousGroup = prevGroup.Index + prevGroup.Length;
+                        before = templateString.Substring(endOfPreviousGroup, group.Index - endOfPreviousGroup);
+                    }
+
+                    if (before.Length > 0)
+                    {
+                        var id = Chunk.StringPool.FetchOrAdd(before);
+                        Chunk.CodeGenerator.Emit(
+                            OpCode.LDSTR,
+                            (int)id
+                        );
+                    }
+
+                    EmitVarGet(symbolName);
+                    Chunk.CodeGenerator.Emit(OpCode.TOSTRING);
+                    additionCount++;
+
+                    if (before.Length > 0)
+                    {
+                        Chunk.CodeGenerator.Emit(OpCode.ADD);
+                    }
+                }
+
+                var tail = templateString.Substring(endOfLastGroup);
+                if (tail.Length > 0)
+                {
+                    var id = Chunk.StringPool.FetchOrAdd(tail);
+                    Chunk.CodeGenerator.Emit(
+                        OpCode.LDSTR,
+                        (int)id
+                    );
+                    Chunk.CodeGenerator.Emit(OpCode.ADD);
+                }
+
+                for (var i = 0; i < additionCount - 1; i++)
+                {
+                    Chunk.CodeGenerator.Emit(OpCode.ADD);
+                }
+            }
+            else
+            {
+                var id = Chunk.StringPool.FetchOrAdd(stringConstant.Value);
+                Chunk.CodeGenerator.Emit(
+                    OpCode.LDSTR,
+                    (int)id
+                );
+            }
         }
     }
 }

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/001_constants.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/001_constants.vil
@@ -42,3 +42,57 @@ fn infinity_is_a_number_too() {
 fn can_invert_infinity() {
   assert.not_equal(Infinity, -Infinity);
 }
+
+#[test]
+fn interpolated_string_locals_only_before_and_after_present() {
+  val a = 21.37;
+  val b = "12345";
+  
+  assert.equal(
+    "nyaa  ($a), $b, uwu", 
+    'nyaa  (21.37), 12345, uwu'
+  ); 
+}
+
+#[test]
+fn interpolated_string_locals_only_after_present() {
+  val a = 21.37;
+  val b = "12345";
+  
+  assert.equal(
+    "$a, $b, uwu", 
+    '21.37, 12345, uwu'
+  ); 
+}
+
+#[test]
+fn interpolated_string_locals_only() {
+  val a = 21.37;
+  val b = "12345";
+  
+  assert.equal(
+    "$a, $b", 
+    '21.37, 12345'
+  ); 
+}
+
+#[test]
+fn interpolated_string_locals_and_globals() {
+  val a = 21.37;
+  val b = "12345";
+  jp2 = "gmd";
+  
+  assert.equal(
+    "$a, $b, $jp2", 
+    '21.37, 12345, gmd'
+  ); 
+}
+#[test]
+fn interpolated_string_symbol_prompt_only() {
+  val b = "12345";
+  
+  assert.equal(
+    "$, $b", 
+    '$, 12345'
+  ); 
+}


### PR DESCRIPTION
This pull request makes it so double-quoted strings (`""`) are able to refer to symbols at runtime via symbol reference constructs (e.g. `$identifier_name`) - they are interpolated, and single-quoted strings remain without that capability - they are referred to as plain strings.

Interpolation in this version does not support any kind of expressions, or formatting. Interpolated symbols get converted to their string representation automatically.