### PR TITLE
Add optional parameter lists for function definitions

### DIFF
--- a/Core/EVIL.Grammar/AST/Expressions/FnExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/FnExpression.cs
@@ -5,17 +5,21 @@ namespace EVIL.Grammar.AST.Expressions
 {
     public sealed class FnExpression : Expression
     {
-        public ParameterList ParameterList { get; }
+        public ParameterList? ParameterList { get; }
         public Statement Statement { get; }
 
         public FnExpression(
-            ParameterList parameterList,
+            ParameterList? parameterList,
             Statement statement)
         {
             ParameterList = parameterList;
             Statement = statement;
 
-            Reparent(ParameterList);
+            if (ParameterList != null)
+            {
+                Reparent(ParameterList);
+            }
+
             Reparent(Statement);
         }
     }

--- a/Core/EVIL.Grammar/AST/Expressions/SelfFnExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/SelfFnExpression.cs
@@ -6,17 +6,21 @@ namespace EVIL.Grammar.AST.Expressions
 {
     public class SelfFnExpression : Expression
     {
-        public ParameterList ParameterList { get; }
+        public ParameterList? ParameterList { get; }
         public Statement Statement { get; }
 
         public SelfFnExpression(
-            ParameterList parameterList,
+            ParameterList? parameterList,
             Statement statement)
         {
             ParameterList = parameterList;
             Statement = statement;
 
-            Reparent(ParameterList);
+            if (ParameterList != null)
+            {
+                Reparent(ParameterList);
+            }
+
             Reparent(Statement);
         }
     }

--- a/Core/EVIL.Grammar/AST/Statements/FnStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/FnStatement.cs
@@ -7,14 +7,14 @@ namespace EVIL.Grammar.AST.Statements.TopLevel
     public sealed class FnStatement : Statement
     {
         public IdentifierNode Identifier { get; }
-        public ParameterList ParameterList { get; }
+        public ParameterList? ParameterList { get; }
         public Statement Statement { get; }
         public List<AttributeNode> Attributes { get; }
         public bool IsLocalDefintion { get; }
 
         public FnStatement(
             IdentifierNode identifier,
-            ParameterList parameterList,
+            ParameterList? parameterList,
             Statement statement,
             List<AttributeNode> attributes,
             bool isLocalDefintion)
@@ -26,7 +26,12 @@ namespace EVIL.Grammar.AST.Statements.TopLevel
             IsLocalDefintion = isLocalDefintion;
 
             Reparent(Identifier);
-            Reparent(ParameterList);
+
+            if (ParameterList != null)
+            {
+                Reparent(ParameterList);
+            }
+
             Reparent(Statement);
             Reparent(Attributes);
         }

--- a/Core/EVIL.Grammar/AST/Statements/FnTargetedStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/FnTargetedStatement.cs
@@ -9,7 +9,7 @@ namespace EVIL.Grammar.AST.Statements
     {
         public AstNode PrimaryTarget { get; }
         public IdentifierNode SecondaryIdentifier { get; }
-        public ParameterList ParameterList { get; }
+        public ParameterList? ParameterList { get; }
         public Statement Statement { get; }
         public List<AttributeNode> Attributes { get; }
         public bool IsSelfTargeting => PrimaryTarget is SelfExpression;
@@ -17,7 +17,7 @@ namespace EVIL.Grammar.AST.Statements
         public FnTargetedStatement(
             AstNode primaryTarget,
             IdentifierNode secondaryIdentifier,
-            ParameterList parameterList,
+            ParameterList? parameterList,
             Statement statement,
             List<AttributeNode> attributes)
         {
@@ -29,7 +29,12 @@ namespace EVIL.Grammar.AST.Statements
 
             Reparent(PrimaryTarget);
             Reparent(SecondaryIdentifier);
-            Reparent(ParameterList);
+
+            if (ParameterList != null)
+            {
+                Reparent(ParameterList);
+            }
+
             Reparent(Statement);
             Reparent(Attributes);
         }

--- a/Core/EVIL.Grammar/AST/Statements/OverrideStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/OverrideStatement.cs
@@ -8,13 +8,13 @@ namespace EVIL.Grammar.AST.Statements
     {
         public Expression Target { get; }
         public TableOverride Override { get; }
-        public ParameterList ParameterList { get; }
+        public ParameterList? ParameterList { get; }
         public Statement Statement { get; }
 
         public OverrideStatement(
             Expression target,
             TableOverride @override,
-            ParameterList parameterList,
+            ParameterList? parameterList,
             Statement statement
         )
         {
@@ -23,7 +23,14 @@ namespace EVIL.Grammar.AST.Statements
             ParameterList = parameterList;
             Statement = statement;
             
-            Reparent(Target, ParameterList, Statement);
+            Reparent(Target);
+
+            if (ParameterList != null)
+            {
+                Reparent(ParameterList);
+            }
+
+            Reparent(Statement);
         }
     }
 }

--- a/Core/EVIL.Grammar/EVIL.Grammar.csproj
+++ b/Core/EVIL.Grammar/EVIL.Grammar.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>11.0</LangVersion>
         
-        <Version>3.3.0</Version>
+        <Version>3.4.0</Version>
         <AssemblyName>EVIL.Grammar</AssemblyName>
         <AssemblyTitle>EVIL.Grammar</AssemblyTitle>
     </PropertyGroup>

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.FnExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.FnExpression.cs
@@ -1,5 +1,6 @@
 using EVIL.Grammar.AST.Base;
 using EVIL.Grammar.AST.Expressions;
+using EVIL.Grammar.AST.Miscellaneous;
 using EVIL.Lexical;
 
 namespace EVIL.Grammar.Parsing
@@ -9,7 +10,12 @@ namespace EVIL.Grammar.Parsing
         private FnExpression FnExpression()
         {
             var (line, col) = Match(Token.Fn);
-            var parameterList = ParameterList();
+            
+            ParameterList? parameterList = null;
+            if (CurrentToken == Token.LParenthesis)
+            {
+                parameterList = ParameterList();
+            }
 
             Statement statement;
             if (CurrentToken == Token.LBrace)

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.SelfFnExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.SelfFnExpression.cs
@@ -1,5 +1,6 @@
 using EVIL.Grammar.AST.Base;
 using EVIL.Grammar.AST.Expressions;
+using EVIL.Grammar.AST.Miscellaneous;
 using EVIL.Lexical;
 
 namespace EVIL.Grammar.Parsing
@@ -11,7 +12,12 @@ namespace EVIL.Grammar.Parsing
             var (line, col) = Match(Token.Self);
             Match(Token.DoubleColon);
             Match(Token.Fn);
-            var parameterList = ParameterList();
+
+            ParameterList? parameterList = null;
+            if (CurrentToken == Token.LParenthesis)
+            {
+                parameterList = ParameterList();
+            }
 
             Statement statement;
             if (CurrentToken == Token.LBrace)

--- a/Core/EVIL.Grammar/Parsing/Statements/Parser.FnStatement.cs
+++ b/Core/EVIL.Grammar/Parsing/Statements/Parser.FnStatement.cs
@@ -70,8 +70,12 @@ namespace EVIL.Grammar.Parsing
                 
                 secondaryIdentifier = Identifier();
             }
-            
-            var parameterList = ParameterList();
+
+            ParameterList? parameterList = null;
+            if (CurrentToken == Token.LParenthesis)
+            {
+                parameterList = ParameterList();
+            }
 
             Statement statement;
             if (CurrentToken == Token.LBrace)

--- a/Core/EVIL.Grammar/Parsing/Statements/Parser.OverrideStatement.cs
+++ b/Core/EVIL.Grammar/Parsing/Statements/Parser.OverrideStatement.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EVIL.CommonTypes.TypeSystem;
 using EVIL.Grammar.AST.Base;
+using EVIL.Grammar.AST.Miscellaneous;
 using EVIL.Grammar.AST.Statements;
 using EVIL.Lexical;
 
@@ -64,7 +65,12 @@ namespace EVIL.Grammar.Parsing
             }
 
             Match(CurrentToken);
-            var parameterList = ParameterList();
+            
+            ParameterList? parameterList = null;
+            if (CurrentToken == Token.LParenthesis)
+            {
+                parameterList = ParameterList();
+            }
             
             Statement statement;
             if (CurrentToken == Token.LBrace)

--- a/FrontEnd/EVIL.evil/EVIL.evil.csproj
+++ b/FrontEnd/EVIL.evil/EVIL.evil.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>evil</AssemblyName>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/VirtualMachine/Ceres/Ceres.csproj
+++ b/VirtualMachine/Ceres/Ceres.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
     
-    <Version>5.2.1</Version>
+    <Version>5.3.1</Version>
     <AssemblyName>Ceres</AssemblyName>
     <AssemblyTitle>Ceres</AssemblyTitle>
     

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Expression.Fn.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Expression.Fn.cs
@@ -13,7 +13,11 @@ namespace Ceres.TranslationEngine
                 {
                     Chunk.DebugDatabase.DefinedOnLine = fnExpression.Line;
 
-                    Visit(fnExpression.ParameterList);
+                    if (fnExpression.ParameterList != null)
+                    {
+                        Visit(fnExpression.ParameterList);
+                    }
+
                     Visit(fnExpression.Statement);
 
                     FinalizeChunk();

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Expression.SelfFn.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Expression.SelfFn.cs
@@ -15,8 +15,12 @@ namespace Ceres.TranslationEngine
 
                     Chunk.MarkSelfAware();
                     /* implicit `self' */ Chunk.AllocateParameter();
-                    
-                    Visit(selfFnExpression.ParameterList);
+
+                    if (selfFnExpression.ParameterList != null)
+                    {
+                        Visit(selfFnExpression.ParameterList);
+                    }
+
                     Visit(selfFnExpression.Statement);
                     
                     FinalizeChunk();

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.Fn.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.Fn.cs
@@ -48,7 +48,11 @@ namespace Ceres.TranslationEngine
 
                     InNewLocalScopeDo(() =>
                     {
-                        Visit(fnStatement.ParameterList);
+                        if (fnStatement.ParameterList != null)
+                        {
+                            Visit(fnStatement.ParameterList);
+                        }
+
                         Visit(fnStatement.Statement);
                     });
 

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.FnTargeted.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.FnTargeted.cs
@@ -52,7 +52,11 @@ namespace Ceres.TranslationEngine
                         Chunk.MarkSelfAware();
                         /* implicit `self' */ Chunk.AllocateParameter();
 
-                        Visit(fnTargetedStatement.ParameterList);
+                        if (fnTargetedStatement.ParameterList != null)
+                        {
+                            Visit(fnTargetedStatement.ParameterList);
+                        }
+
                         Visit(fnTargetedStatement.Statement);
                         
                         FinalizeChunk();

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.Override.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.Override.cs
@@ -23,7 +23,11 @@ namespace Ceres.TranslationEngine
                 {
                     Chunk.DebugDatabase.DefinedOnLine = overrideStatement.Line;
 
-                    Visit(overrideStatement.ParameterList);
+                    if (overrideStatement.ParameterList != null)
+                    {
+                        Visit(overrideStatement.ParameterList);
+                    }
+
                     Visit(overrideStatement.Statement);
 
                     FinalizeChunk();

--- a/VirtualMachine/Tests/Ceres.LanguageTests/Program.cs
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/Program.cs
@@ -36,8 +36,8 @@ argList.RemoveAll(x => !Directory.Exists(x));
 return await new TestRunner(
     vm, 
     new TestRunnerOptions(
-        FailOnCompilerErrors: args.Contains("--fail-on-compiler-errors"),
-        FailOnTestErrors: args.Contains("--fail-on-test-errors"),
+        FailOnCompilerErrors: failOnCompilerErrors,
+        FailOnTestErrors: failOnTestErrors,
         TestDirectories: argList.ToArray()
     )
 ).RunTests();

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/000_truth.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/000_truth.vil
@@ -1,9 +1,9 @@
-﻿#[test] fn nil_is_false() -> assert.is_false(nil ? true : false);
-#[test] fn zero_is_false() -> assert.is_false(0 ? true : false);
-#[test] fn false_is_false() -> assert.is_false(false ? true : false);
+﻿#[test] fn nil_is_false -> assert.is_false(nil ? true : false);
+#[test] fn zero_is_false -> assert.is_false(0 ? true : false);
+#[test] fn false_is_false -> assert.is_false(false ? true : false);
 
 #[test]
-fn nil_coalesced_to_boolean_is_false() {
+fn nil_converted_to_boolean_is_false {
   val a = !!nil;
   
   assert.is_of_type(a, Boolean);
@@ -11,7 +11,7 @@ fn nil_coalesced_to_boolean_is_false() {
 }
 
 #[test]
-fn zero_coalesced_to_boolean_is_false() {
+fn zero_converted_to_boolean_is_false {
   val a = !!0;
   
   assert.is_of_type(a, Boolean);

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/001_constants.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/001_constants.vil
@@ -1,50 +1,50 @@
 ﻿#[test] 
-fn nil_is_nil() {
+fn nil_is_nil {
   assert.is_of_type(nil, Nil);
   assert.equal(nil, nil);
 }
 
 #[test] 
-fn number_is_number() {
+fn number_is_number {
   assert.is_of_type(21.37, Number);
   assert.equal(21.37, 21.37);
 }
 
 #[test] 
-fn string_is_string() {
+fn string_is_string {
   assert.is_of_type("jp2gmd", String);
   assert.equal("jp2gmd", "jp2gmd");
 }
 
 #[test]
-fn false_is_false() {
+fn false_is_false {
   assert.is_of_type(false, Boolean);
   assert.equal(false, false);
 }
 
 #[test]
-fn true_is_true() {
+fn true_is_true {
   assert.is_of_type(true, Boolean);
   assert.equal(true, true);
 }
 
 #[test]
-fn nan_is_in_fact_a_number() {
+fn nan_is_in_fact_a_number {
   assert.is_of_type(NaN, Number);
 }
 
 #[test]
-fn infinity_is_a_number_too() {
+fn infinity_is_a_number_too {
   assert.is_of_type(Infinity, Number);
 }
 
 #[test] 
-fn can_invert_infinity() {
+fn can_invert_infinity {
   assert.not_equal(Infinity, -Infinity);
 }
 
 #[test]
-fn interpolated_string_locals_only_before_and_after_present() {
+fn interpolated_string_locals_only_before_and_after_present {
   val a = 21.37;
   val b = "12345";
   
@@ -55,7 +55,7 @@ fn interpolated_string_locals_only_before_and_after_present() {
 }
 
 #[test]
-fn interpolated_string_locals_only_after_present() {
+fn interpolated_string_locals_only_after_present {
   val a = 21.37;
   val b = "12345";
   
@@ -66,7 +66,7 @@ fn interpolated_string_locals_only_after_present() {
 }
 
 #[test]
-fn interpolated_string_locals_only() {
+fn interpolated_string_locals_only {
   val a = 21.37;
   val b = "12345";
   
@@ -77,7 +77,7 @@ fn interpolated_string_locals_only() {
 }
 
 #[test]
-fn interpolated_string_locals_and_globals() {
+fn interpolated_string_locals_and_globals {
   val a = 21.37;
   val b = "12345";
   jp2 = "gmd";
@@ -88,7 +88,7 @@ fn interpolated_string_locals_and_globals() {
   ); 
 }
 #[test]
-fn interpolated_string_symbol_prompt_only() {
+fn interpolated_string_symbol_prompt_only {
   val b = "12345";
   
   assert.equal(

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/002_basic_operators.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/002_basic_operators.vil
@@ -1,52 +1,52 @@
-#[test] fn eq() -> assert(2 == 2);
-#[test] fn ne() -> assert(10 != 5);
-#[test] fn gt() -> assert(10 > 2);
-#[test] fn lt() -> assert(1 < 3);
-#[test] fn gte() -> assert(2 >= 2);
-#[test] fn lte() -> assert(4 <= 4);
+#[test] fn eq -> assert(2 == 2);
+#[test] fn ne -> assert(10 != 5);
+#[test] fn gt -> assert(10 > 2);
+#[test] fn lt -> assert(1 < 3);
+#[test] fn gte -> assert(2 >= 2);
+#[test] fn lte -> assert(4 <= 4);
 
-#[test] fn add_int() -> assert.equal(2 + 2, 4);
-#[test] fn add_fp64() -> assert.equal(21 + 0.37, 21.37);
+#[test] fn add_int -> assert.equal(2 + 2, 4);
+#[test] fn add_fp64 -> assert.equal(21 + 0.37, 21.37);
 
-#[test] fn sub_int() -> assert.equal(3 - 1, 2);
-#[test] fn sub_fp64() -> assert.equal(3 - 0.863, 2.137);
+#[test] fn sub_int -> assert.equal(3 - 1, 2);
+#[test] fn sub_fp64 -> assert.equal(3 - 0.863, 2.137);
 
-#[test] fn div_int() -> assert.equal(20 / 5, 4);
-#[test] fn div_fp64() -> assert.equal(1923.3 / 9, 213.7);
+#[test] fn div_int -> assert.equal(20 / 5, 4);
+#[test] fn div_fp64 -> assert.equal(1923.3 / 9, 213.7);
 
-#[test] fn mod_int() -> assert.equal(9 % 5, 4);
-#[test] fn mod_fp64() -> assert.approx_equal(21 % 3.7, 2.5);
-#[test] fn mod_fp64_neg() -> assert.equal((-1) % 4, 3);
+#[test] fn mod_int -> assert.equal(9 % 5, 4);
+#[test] fn mod_fp64 -> assert.approx_equal(21 % 3.7, 2.5);
+#[test] fn mod_fp64_neg -> assert.equal((-1) % 4, 3);
 
-#[test] fn mul_int() -> assert.equal(4 * 20, 80);
-#[test] fn mul_fp64() -> assert.equal(20 * 0.010685, 0.2137);
+#[test] fn mul_int -> assert.equal(4 * 20, 80);
+#[test] fn mul_fp64 -> assert.equal(20 * 0.010685, 0.2137);
 
-#[test] fn band() -> assert.equal(0xFFFF & 0x0F00, 0x0F00);
-#[test] fn bxor() -> assert.equal(0xFFFF ^ 0xFFF0, 0x000F);
-#[test] fn bnot() -> assert.equal(~0 & 0xFFFF, 0xFFFF);
-#[test] fn bor() -> assert.equal(0x00F0 | 0xF000 | 0x0F00, 0xFFF0);
-#[test] fn shl_num() -> assert.equal(1 << 4, 16);
-#[test] fn shr_num() -> assert.equal(0x80 >> 2, 32);
-#[test] fn shl_str() -> assert.equal("nyaaaaaa" << 2, "aaaaaa");
-#[test] fn shr_str() -> assert.equal("nyaaaaaa" >> 2, "nyaaaa");
+#[test] fn band -> assert.equal(0xFFFF & 0x0F00, 0x0F00);
+#[test] fn bxor -> assert.equal(0xFFFF ^ 0xFFF0, 0x000F);
+#[test] fn bnot -> assert.equal(~0 & 0xFFFF, 0xFFFF);
+#[test] fn bor -> assert.equal(0x00F0 | 0xF000 | 0x0F00, 0xFFF0);
+#[test] fn shl_num -> assert.equal(1 << 4, 16);
+#[test] fn shr_num -> assert.equal(0x80 >> 2, 32);
+#[test] fn shl_str -> assert.equal("nyaaaaaa" << 2, "aaaaaa");
+#[test] fn shr_str -> assert.equal("nyaaaaaa" >> 2, "nyaaaa");
 
-#[test] fn exist_str() -> assert("a" in "blah");
-#[test] fn exist_tbl() -> assert("a" in { "a" => 2137 });
-#[test] fn exist_arr() -> assert("a" in array { "a", "b", "c" });
-#[test] fn noexist_str() -> assert("f" !in "blah");
-#[test] fn noexist_tbl() -> assert("a" !in { });
-#[test] fn noexist_arr() -> assert("x" !in array { "a", "b", "c" });
+#[test] fn exist_str -> assert("a" in "blah");
+#[test] fn exist_tbl -> assert("a" in { "a" => 2137 });
+#[test] fn exist_arr -> assert("a" in array { "a", "b", "c" });
+#[test] fn noexist_str -> assert("f" !in "blah");
+#[test] fn noexist_tbl -> assert("a" !in { });
+#[test] fn noexist_arr -> assert("x" !in array { "a", "b", "c" });
 
-#[test] fn type_positive() -> assert("a" is String);
-#[test] fn type_negative() -> assert.is_false("a" is Number);
-#[test] fn not_type_positive() -> assert("a" !is Number);
-#[test] fn not_type_negative() -> assert.is_false(21 !is Number);
+#[test] fn type_positive -> assert("a" is String);
+#[test] fn type_negative -> assert.is_false("a" is Number);
+#[test] fn not_type_positive -> assert("a" !is Number);
+#[test] fn not_type_negative -> assert.is_false(21 !is Number);
 
-#[test] fn len_str() -> assert.equal(#"ąćężółń", 7);
-#[test] fn len_tbl() -> assert.equal(#{2,1,3,7}, 4);
+#[test] fn len_str -> assert.equal(#"ąćężółń", 7);
+#[test] fn len_tbl -> assert.equal(#{2,1,3,7}, 4);
 
 #[test]
-fn tostr_num() {
+fn tostr_num {
   val str = @4;
   
   assert.is_of_type(str, String);
@@ -54,7 +54,7 @@ fn tostr_num() {
 }
 
 #[test]
-fn tostr_str() {
+fn tostr_str {
   val str = @"asdfg";
   
   assert.is_of_type(str, String);
@@ -62,7 +62,7 @@ fn tostr_str() {
 }
 
 #[test]
-fn tostr_bool_true() {
+fn tostr_bool_true {
   val str = @true;
   
   assert.is_of_type(str, String);
@@ -70,7 +70,7 @@ fn tostr_bool_true() {
 }
 
 #[test]
-fn tostr_bool_false() {
+fn tostr_bool_false {
   val str = @false;
  
   assert.is_of_type(str, String);
@@ -78,7 +78,7 @@ fn tostr_bool_false() {
 }
 
 #[test]
-fn tonum_int() {
+fn tonum_int {
   val num = $"2137";
   
   assert.is_of_type(num, Number);
@@ -86,7 +86,7 @@ fn tonum_int() {
 }
 
 #[test]
-fn tonum_fp64() {
+fn tonum_fp64 {
   val num = $"21.37";
   
   assert.is_of_type(num, Number);
@@ -94,7 +94,7 @@ fn tonum_fp64() {
 }
 
 #[test]
-fn tonum_bool_false() {
+fn tonum_bool_false {
   val num = $(false);
   
   assert.is_of_type(num, Number);
@@ -102,7 +102,7 @@ fn tonum_bool_false() {
 }
 
 #[test]
-fn tonum_bool_true() {
+fn tonum_bool_true {
   val num = $(true);
   
   assert.is_of_type(num, Number);
@@ -110,7 +110,7 @@ fn tonum_bool_true() {
 }
 
 #[test]
-fn postinc_var() {
+fn postinc_var {
   rw val a = 10;
   
   assert.equal(a++, 10);
@@ -118,7 +118,7 @@ fn postinc_var() {
 }
 
 #[test]
-fn postinc_tbl_member() {
+fn postinc_tbl_member {
   val a = { 10 };
   
   assert.equal(a[0]++, 10);
@@ -126,7 +126,7 @@ fn postinc_tbl_member() {
 }
 
 #[test]
-fn postinc_arr_element() {
+fn postinc_arr_element {
   val a = array { 3 };
   
   assert.equal(a[0]++, 3);
@@ -134,7 +134,7 @@ fn postinc_arr_element() {
 }
 
 #[test]
-fn preinc_var() { 
+fn preinc_var { 
   rw val a = 10;
   
   assert.equal(++a, 11);
@@ -142,7 +142,7 @@ fn preinc_var() {
 }
 
 #[test]
-fn preinc_tbl_member() {
+fn preinc_tbl_member {
   val a = { 10 };
   
   assert.equal(++a[0], 11);
@@ -150,7 +150,7 @@ fn preinc_tbl_member() {
 }
 
 #[test]
-fn preinc_arr_element() {
+fn preinc_arr_element {
   val a = array { 3 };
   
   assert.equal(++a[0], 4);
@@ -158,7 +158,7 @@ fn preinc_arr_element() {
 }
 
 #[test]
-fn postdec_var() {
+fn postdec_var {
   rw val a = 10;
   
   assert.equal(a--, 10); 
@@ -166,7 +166,7 @@ fn postdec_var() {
 }
 
 #[test]
-fn postdec_tbl_member() {
+fn postdec_tbl_member {
   val a = { 10 };
   
   assert.equal(a[0]--, 10);
@@ -174,7 +174,7 @@ fn postdec_tbl_member() {
 }
 
 #[test]
-fn postdec_arr_element() {
+fn postdec_arr_element {
   val a = array { 3 };
   
   assert.equal(a[0]--, 3);
@@ -182,7 +182,7 @@ fn postdec_arr_element() {
 }
 
 #[test]
-fn predec_var() {
+fn predec_var {
   rw val a = 10;
   
   assert.equal(--a, 9);
@@ -190,7 +190,7 @@ fn predec_var() {
 }
 
 #[test]
-fn predec_tbl_member() {
+fn predec_tbl_member {
   val a = { 10 };
   
   assert.equal(--a[0], 9);
@@ -198,7 +198,7 @@ fn predec_tbl_member() {
 }
 
 #[test]
-fn predec_arr_element() {
+fn predec_arr_element {
   val a = array { 3 };
   
   assert.equal(--a[0], 2);
@@ -206,7 +206,7 @@ fn predec_arr_element() {
 }
 
 #[test]
-fn nil_coalescing_left_is_nil() {
+fn nil_coalescing_left_is_nil {
   val a = nil;
   val b = 21.37;
   
@@ -216,7 +216,7 @@ fn nil_coalescing_left_is_nil() {
 }
 
 #[test]
-fn nil_coalescing_right_is_nil() {
+fn nil_coalescing_right_is_nil {
   val a = nil;
   val b = 21.37;
   
@@ -226,7 +226,7 @@ fn nil_coalescing_right_is_nil() {
 }
 
 #[test]
-fn nil_coalescing_both_nil() {
+fn nil_coalescing_both_nil {
   val a = nil;
   val b = nil;
   
@@ -236,7 +236,7 @@ fn nil_coalescing_both_nil() {
 }
 
 #[test]
-fn nil_coalescing_multiple_values() {
+fn nil_coalescing_multiple_values {
   val a = nil;
   val b = nil;
   val c = 21.37;

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/003_ternary_operator.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/003_ternary_operator.vil
@@ -1,5 +1,5 @@
 ﻿#[test] 
-fn ternary_true_with_constant() {
+fn ternary_true_with_constant {
   val result = true 
     ? 21.37 
     : "something went terribly wrong";
@@ -8,7 +8,7 @@ fn ternary_true_with_constant() {
 }
 
 #[test]
-fn ternary_false_with_constant() {
+fn ternary_false_with_constant {
   val result = false 
     ? "something went terribly wrong"
     : "jp2gmd";
@@ -17,7 +17,7 @@ fn ternary_false_with_constant() {
 }
 
 #[test]
-fn ternary_true_with_variable() {
+fn ternary_true_with_variable {
   val x = 25;
   val result = x / 5 == 5 
     ? 213.7 
@@ -27,7 +27,7 @@ fn ternary_true_with_variable() {
 }
 
 #[test]
-fn ternary_false_with_variable() {
+fn ternary_false_with_variable {
   val x = 666;
   val result = x > 999 
     ? "something went terribly wrong" 
@@ -37,7 +37,7 @@ fn ternary_false_with_variable() {
 }
 
 #[test]
-fn ternary_true_nested() {
+fn ternary_true_nested {
   val result = 21 < 37 
     ? "jp2gmd" 
       ? "jeszcze jak" 

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/004_assignment_operators.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/004_assignment_operators.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn assignment_var_direct() {
+fn assignment_var_direct {
   rw val x = 20;
   
   assert.equal(x = 10, 10);
@@ -7,7 +7,7 @@ fn assignment_var_direct() {
 }
 
 #[test]
-fn assignment_var_add() {
+fn assignment_var_add {
   rw val x = 10;
   
   assert.equal(x += 1, 11);
@@ -15,7 +15,7 @@ fn assignment_var_add() {
 }
 
 #[test]
-fn assignment_var_sub() {
+fn assignment_var_sub {
   rw val x = 13;
   
   assert.equal(x -= 1, 12);
@@ -23,7 +23,7 @@ fn assignment_var_sub() {
 }
 
 #[test]
-fn assignment_var_div() {
+fn assignment_var_div {
   rw val x = 26;
   
   assert.equal(x /= 2, 13);
@@ -31,7 +31,7 @@ fn assignment_var_div() {
 }
 
 #[test]
-fn assignment_var_mod() {
+fn assignment_var_mod {
   rw val x = 30;
   
   assert.equal(x %= 16, 14);
@@ -39,7 +39,7 @@ fn assignment_var_mod() {
 }
 
 #[test]
-fn assignment_var_mul() {
+fn assignment_var_mul {
   rw val x = 7.5;
   
   assert.equal(x *= 2, 15);
@@ -47,7 +47,7 @@ fn assignment_var_mul() {
 }
 
 #[test]
-fn assignment_var_band() {
+fn assignment_var_band {
   rw val x = 0xFFFF;
   
   assert.equal(x &= 0x0FF0, 0x0FF0);
@@ -55,7 +55,7 @@ fn assignment_var_band() {
 }
 
 #[test]
-fn assignment_var_bor() {
+fn assignment_var_bor {
   rw val x = 0xF000;
   
   assert.equal(x |= 0x0FF0, 0xFFF0);
@@ -63,7 +63,7 @@ fn assignment_var_bor() {
 }
 
 #[test]
-fn assignment_var_bxor() {
+fn assignment_var_bxor {
   rw val x = 0xF0F0;
   
   assert.equal(x ^= 0xFFFF, 0x0F0F);
@@ -71,7 +71,7 @@ fn assignment_var_bxor() {
 }
 
 #[test]
-fn assignment_var_shl() {
+fn assignment_var_shl {
   rw val x = 0xF;
   
   assert.equal(x <<= 16, 0xF0000);
@@ -79,7 +79,7 @@ fn assignment_var_shl() {
 }
 
 #[test]
-fn assignment_var_shr() {
+fn assignment_var_shr {
   rw val x = 0xFFFF;
   
   assert.equal(x >>= 8, 0x00FF);
@@ -87,7 +87,7 @@ fn assignment_var_shr() {
 }
 
 #[test]
-fn chained_assignment_direct() {
+fn chained_assignment_direct {
   rw val a, b, c, d;
   val result = (a = b = c = d = 10);
   
@@ -99,7 +99,7 @@ fn chained_assignment_direct() {
 }
 
 #[test]
-fn chained_assignment_add() {
+fn chained_assignment_add {
   rw val a = 5, b = 10, c = 15, d = 20;
   val result = (a += b += c += d += 5);
   
@@ -111,7 +111,7 @@ fn chained_assignment_add() {
 }
 
 #[test]
-fn chained_assignment_sub() {
+fn chained_assignment_sub {
   rw val a = 5, b = 10, c = 15, d = 20;
   val result = (a -= b -= c -= d -= 5);
   
@@ -123,7 +123,7 @@ fn chained_assignment_sub() {
 }
 
 #[test]
-fn chained_assignment_div() {
+fn chained_assignment_div {
   rw val a = 120, b = 60, c = 30, d = 10;
   val result = (a /= b /= c /= d /= 2); 
   
@@ -135,7 +135,7 @@ fn chained_assignment_div() {
 }
 
 #[test]
-fn assignment_tbl_direct() {
+fn assignment_tbl_direct {
   val a = {};
   a[0] = "test";
   
@@ -144,7 +144,7 @@ fn assignment_tbl_direct() {
 }
 
 #[test]
-fn assignment_tbl_add() {
+fn assignment_tbl_add {
   val a = { 10 };
   
   assert.equal(a[0] += 1, 11);
@@ -153,7 +153,7 @@ fn assignment_tbl_add() {
 
 
 #[test]
-fn assignment_tbl_sub() {
+fn assignment_tbl_sub {
   val a = { 13 };
   
   assert.equal(a[0] -= 1, 12);
@@ -161,7 +161,7 @@ fn assignment_tbl_sub() {
 }
 
 #[test]
-fn coalescing_assignment_global() {
+fn coalescing_assignment_global {
   test_global = nil;
   test_global ??= 21.37;
   test_global ??= "a string";
@@ -170,7 +170,7 @@ fn coalescing_assignment_global() {
 }
 
 #[test]
-fn coalescing_assignment_local() {
+fn coalescing_assignment_local {
   rw val test_local = nil;
   test_local ??= 21.37;
   test_local ??= "a string";
@@ -179,7 +179,7 @@ fn coalescing_assignment_local() {
 }
 
 #[test]
-fn coalescing_assignment_table_entry() {
+fn coalescing_assignment_table_entry {
   val t = { };
   t.x ??= 21;
   t.y ??= 37;
@@ -192,7 +192,7 @@ fn coalescing_assignment_table_entry() {
 }
 
 #[test]
-fn chained_coalescing_assignment_table_entry_when_first_is_nil() {
+fn chained_coalescing_assignment_table_entry_when_first_is_nil {
   val t = { };
   val a = "string";
   rw val b = nil;
@@ -204,7 +204,7 @@ fn chained_coalescing_assignment_table_entry_when_first_is_nil() {
 }
 
 #[test]
-fn chained_coalescing_assignment_table_entry_when_first_is_not_nil() {
+fn chained_coalescing_assignment_table_entry_when_first_is_not_nil {
   val t = { };
   rw val a = "string";
   rw val b = nil;

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/005_while_loop.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/005_while_loop.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn while_simple() {
+fn while_simple {
   rw val a = 0;
   
   while (a != 10) {
@@ -10,7 +10,7 @@ fn while_simple() {
 }
 
 #[test]
-fn while_break() {
+fn while_break {
   rw val a = 0;
   
   while (a != 10) {
@@ -25,7 +25,7 @@ fn while_break() {
 }
 
 #[test]
-fn while_skip() {
+fn while_skip {
   rw val a = 10;
   
   while (a--) {
@@ -40,7 +40,7 @@ fn while_skip() {
 }
 
 #[test] 
-fn while_false() {
+fn while_false {
   rw val a = 0;
   
   while (false) {
@@ -51,7 +51,7 @@ fn while_false() {
 }
 
 #[test]
-fn while_nested() {
+fn while_nested {
   rw val a = 10, b, c;
   
   while (a) {

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/006_do_while_loop.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/006_do_while_loop.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn do_while_simple() {
+fn do_while_simple {
   rw val a = 0;
   
   do {
@@ -10,7 +10,7 @@ fn do_while_simple() {
 }
 
 #[test]
-fn do_while_executes_at_least_once() {
+fn do_while_executes_at_least_once {
   rw val a = 0;
   
   do {
@@ -21,7 +21,7 @@ fn do_while_executes_at_least_once() {
 }
 
 #[test]
-fn do_while_break() {
+fn do_while_break {
   rw val a = 10;
   
   do {
@@ -36,7 +36,7 @@ fn do_while_break() {
 }
 
 #[test]
-fn do_while_skip() {
+fn do_while_skip {
   rw val a = 10;
   
   do {
@@ -51,7 +51,7 @@ fn do_while_skip() {
 }
 
 #[test]
-fn do_while_nested() {
+fn do_while_nested {
   rw val a = 10, b, c;
   
   do {

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/007_for_loop.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/007_for_loop.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn for_simple() {
+fn for_simple {
   rw val i;
   for (i = 0; i < 10; ++i) {}
   
@@ -7,7 +7,7 @@ fn for_simple() {
 }
 
 #[test]
-fn for_simple_skip() {
+fn for_simple_skip {
   rw val i;
   
   for (i = 0; i < 10; i++) {
@@ -18,7 +18,7 @@ fn for_simple_skip() {
 }
 
 #[test]
-fn for_simple_break() {
+fn for_simple_break {
   rw val i;
   
   for (i = 0; i < 10; i++) {
@@ -30,7 +30,7 @@ fn for_simple_break() {
 }
 
 #[test]
-fn for_nested() {
+fn for_nested {
   rw val i, j, k;
   
   for (i = 0; i < 10; i++) {
@@ -45,7 +45,7 @@ fn for_nested() {
 }
 
 #[test]
-fn for_nested_break() {
+fn for_nested_break {
   rw val broken = false;
   rw val i;
   
@@ -67,7 +67,7 @@ fn for_nested_break() {
 }
 
 #[test]
-fn for_multiple_statements() {
+fn for_multiple_statements {
   rw val i;
   rw val j;
   

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/008_tables.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/008_tables.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn table_empty() {
+fn table_empty {
   val a = {};
   
   assert.is_of_type(a, Table);
@@ -7,7 +7,7 @@ fn table_empty() {
 }
 
 #[test]
-fn table_value_init() {
+fn table_value_init {
   val a = { 1, 2, 3, 4, 5 };
   
   assert.is_of_type(a, Table);
@@ -21,7 +21,7 @@ fn table_value_init() {
 }
 
 #[test]
-fn table_constkeyed_init() {
+fn table_constkeyed_init {
   val a = {
     "key_a" => 123,
     "key_b" => 234,
@@ -48,7 +48,7 @@ fn table_constkeyed_init() {
 }
 
 #[test]
-fn table_identkeyed() {
+fn table_identkeyed {
   val vec = { x: 21.37, y: 42.74 };
   
   assert.is_of_type(vec, Table);
@@ -62,7 +62,7 @@ fn table_identkeyed() {
 }
 
 #[test]
-fn table_computedkey_init() {
+fn table_computedkey_init {
   val a = {
     [2 + 1.37] => "jp2gmd",
     [21 + $"37"] => "można, jak najbardziej",    
@@ -90,7 +90,7 @@ fn table_computedkey_init() {
 }
 
 #[test]
-fn table_mixed_keying() {
+fn table_mixed_keying {
   val a = { 
     b: "haha funny",
     [213 + .7] => "blah",
@@ -110,7 +110,7 @@ fn table_mixed_keying() {
 }
 
 #[test]
-fn nested_table_indexing() {
+fn nested_table_indexing {
   val a = { 1, { 2, 3, { 4, 5, 6, { 7, 8, 9, 10, 21.37 } } } };
   
   assert.is_of_type(a, Table); 
@@ -118,7 +118,7 @@ fn nested_table_indexing() {
 }
 
 #[test]
-fn nested_table_identifier_indexing() {
+fn nested_table_identifier_indexing {
   val a = { b: { c: { d: { j: { p2gmd: 213.7 } } } } };
   
   assert.is_of_type(a, Table);
@@ -126,7 +126,7 @@ fn nested_table_identifier_indexing() {
 }
 
 #[test]
-fn tables_are_references() {
+fn tables_are_references {
   val t = { { 21.37 } };
   val t2 = { t[0] };
   
@@ -135,14 +135,14 @@ fn tables_are_references() {
   assert.equal(t[0][0], "21.37"); 
 }
 
-#[test] fn table_equality_is_by_reference() -> assert({ 0, 255, 0 } != { 0, 255, 0 });
-#[test] fn table_is_deeply_equal_flat() -> assert({ 0, 255, 0 } <==> { 0, 255, 0 });
-#[test] fn table_is_deeply_not_equal_flat() -> assert({ 0, 1, 2 } <!=> { 3, 4, 5 });
-#[test] fn table_is_deeply_equal_nested() -> assert({ 0, 1, 2, { 3, 4, 5 }, 21.37 } <==> { 0, 1, 2, { 3, 4, 5 }, 21.37 });
-#[test] fn table_is_deeply_not_equal_nested() -> assert({ 0, 1, 2, { 3, 4, 5 }, 21.37 } <!=> { 0, 1, 2, { 3, 4, 5 }, 213.7 });
+#[test] fn table_equality_is_by_reference -> assert({ 0, 255, 0 } != { 0, 255, 0 });
+#[test] fn table_is_deeply_equal_flat -> assert({ 0, 255, 0 } <==> { 0, 255, 0 });
+#[test] fn table_is_deeply_not_equal_flat -> assert({ 0, 1, 2 } <!=> { 3, 4, 5 });
+#[test] fn table_is_deeply_equal_nested -> assert({ 0, 1, 2, { 3, 4, 5 }, 21.37 } <==> { 0, 1, 2, { 3, 4, 5 }, 21.37 });
+#[test] fn table_is_deeply_not_equal_nested -> assert({ 0, 1, 2, { 3, 4, 5 }, 21.37 } <!=> { 0, 1, 2, { 3, 4, 5 }, 213.7 });
 
 #[test] 
-fn table_tricky_works() {
+fn table_tricky_works {
   __tricky.d20 = 1337;
   
   assert.equal(__tricky.d20, nil);

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/009_invoke.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/009_invoke.vil
@@ -1,8 +1,8 @@
-﻿fn noret() { }
+﻿fn noret { }
 fn add(a, b) -> a + b;
-fn get_add_fn() -> add; 
+fn get_add_fn -> add; 
 
-#[test] fn no_ret_is_nil() -> assert.equal(noret(), nil);
-#[test] fn invoke() -> assert.equal(add(2, 2), 4);
-#[test] fn invoke_indirect() -> assert.equal(get_add_fn()(3, 3), 6);
-#[test] fn invoke_native() -> assert.equal(__native_func(1, 2, 3, 21.37), 21.37);
+#[test] fn no_ret_is_nil -> assert.equal(noret(), nil);
+#[test] fn invoke -> assert.equal(add(2, 2), 4);
+#[test] fn invoke_indirect -> assert.equal(get_add_fn()(3, 3), 6);
+#[test] fn invoke_native -> assert.equal(__native_func(1, 2, 3, 21.37), 21.37);

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/010_array.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/010_array.vil
@@ -1,7 +1,7 @@
-#[test] fn arr_size() -> assert.equal(#array(10), 10);
+#[test] fn arr_size -> assert.equal(#array(10), 10);
 
 #[test]
-fn arr_set_val() {
+fn arr_set_val {
   val arr = array(2);
   arr[0] = 10;
   arr[1] = 21.37;
@@ -15,7 +15,7 @@ fn arr_set_val() {
 }
 
 #[test]
-fn arr_init_val() {
+fn arr_init_val {
   val arr = array { 21.37, 11.11 };
   
   assert.is_of_type(arr, Array);
@@ -27,7 +27,7 @@ fn arr_init_val() {
 }
 
 #[test]
-fn arr_each() {
+fn arr_each {
   val arr = array { 2, 4, 6, 8, 10 };
   
   rw val prev_i = 0;
@@ -45,7 +45,7 @@ fn arr_each() {
 }
 
 #[test]
-fn arr_for() {
+fn arr_for {
   val arr = array { 4, 8, 12, 16 };
 
   for (rw val i = 0; i < #arr; i++) {
@@ -54,8 +54,8 @@ fn arr_for() {
 }
 
 #[test]
-fn func_in_arr() {
-  val arr = array { fn() -> 21.37 };
+fn func_in_arr {
+  val arr = array { fn -> 21.37 };
   
   assert.is_of_type(arr, Array);
   assert.equal(arr[0](), 21.37);  

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/011_type.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/011_type.vil
@@ -1,19 +1,19 @@
 ﻿fn testchunk() { }
 
-#[test] fn type_nil() -> assert.equal(typeof(nil), Nil);
-#[test] fn type_number() -> assert.equal(typeof(2137), Number);
-#[test] fn type_boolean() -> assert.equal(typeof(false), Boolean);
-#[test] fn type_str() -> assert.equal(typeof("jp2gmd"), String);
-#[test] fn type_table() -> assert.equal(typeof({}), Table);
-#[test] fn type_array() -> assert.equal(typeof(array(10)), Array);
-#[test] fn type_chunk() -> assert.equal(typeof(testchunk), Function);
-#[test] fn type_error() -> assert.equal(typeof(error("uwu")), Error);
-#[test] fn type_type() -> assert.equal(typeof(typeof(0)), Type);
-#[test] fn type_nativefunction() -> assert.equal(typeof(__native_func), NativeFunction);
-#[test] fn type_nativeobject() -> assert.equal(typeof(__native_object), NativeObject);
+#[test] fn type_nil -> assert.equal(typeof(nil), Nil);
+#[test] fn type_number -> assert.equal(typeof(2137), Number);
+#[test] fn type_boolean -> assert.equal(typeof(false), Boolean);
+#[test] fn type_str -> assert.equal(typeof("jp2gmd"), String);
+#[test] fn type_table -> assert.equal(typeof({}), Table);
+#[test] fn type_array -> assert.equal(typeof(array(10)), Array);
+#[test] fn type_chunk -> assert.equal(typeof(testchunk), Function);
+#[test] fn type_error -> assert.equal(typeof(error("uwu")), Error);
+#[test] fn type_type -> assert.equal(typeof(typeof(0)), Type);
+#[test] fn type_nativefunction -> assert.equal(typeof(__native_func), NativeFunction);
+#[test] fn type_nativeobject -> assert.equal(typeof(__native_object), NativeObject);
 
 #[test]
-fn value_is_nil() {
+fn value_is_nil {
   val testval = nil;
   
   assert(testval is Nil);
@@ -21,7 +21,7 @@ fn value_is_nil() {
 }
 
 #[test]
-fn value_is_number() {
+fn value_is_number {
   val testval = 2137;
   
   assert(testval is Number);
@@ -29,7 +29,7 @@ fn value_is_number() {
 }
 
 #[test]
-fn value_is_boolean() {
+fn value_is_boolean {
   val testval = false;
   
   assert(testval is Boolean);
@@ -37,7 +37,7 @@ fn value_is_boolean() {
 }
 
 #[test]
-fn value_is_string() {
+fn value_is_string {
   val testval = "2137";
   
   assert(testval is String);
@@ -45,13 +45,13 @@ fn value_is_string() {
 }
 
 #[test]
-fn value_is_table() {
+fn value_is_table {
   val testval = { 1, 2, 3 };
   assert(testval is Table);
 }
 
 #[test]
-fn values_in_table_are_matching_types() {
+fn values_in_table_are_matching_types {
   val testval = {
     "a" => 123,
     10 => "111"
@@ -63,37 +63,37 @@ fn values_in_table_are_matching_types() {
 }
 
 #[test]
-fn value_is_chunk() {
+fn value_is_chunk {
   val testval = fn(a, b) -> a + b;
   assert(testval is Function);
 }
 
 #[test]
-fn value_is_error() {
+fn value_is_error {
   val testval = error("hello!");
   assert(testval is Error);
 }
 
 #[test]
-fn value_is_native_func() {
+fn value_is_native_func {
   val testval = __native_func;
   assert(testval is NativeFunction);
 }
 
 #[test]
-fn value_is_native_object() {
+fn value_is_native_object {
   val testval = __native_object;
   assert(testval is NativeObject);
 }
 
 #[test]
-fn value_is_not_number() {
+fn value_is_not_number {
   val testval = "string lol";
   assert(testval !is Number);
 }
 
 #[test]
-fn value_is_not_string() {
+fn value_is_not_string {
   val testval = 21.37;
   assert(testval !is String);
 }

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/012_if_statement.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/012_if_statement.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn if_condition_simple() {
+fn if_condition_simple {
   rw val result = 0;
   if (true) { result = 1; }
   
@@ -7,7 +7,7 @@ fn if_condition_simple() {
 }
 
 #[test]
-fn if_else() {
+fn if_else {
   rw val result = 0;
   
   if (false) { result = 1; }
@@ -17,7 +17,7 @@ fn if_else() {
 }
 
 #[test] 
-fn if_elif_else() {
+fn if_elif_else {
   rw val result = 0;
   
   if (1 == 2) { result = 1; }
@@ -28,7 +28,7 @@ fn if_elif_else() {
 }
 
 #[test]
-fn only_first_true_elif_is_executed() {
+fn only_first_true_elif_is_executed {
   rw val result;
   
   if (1 == 2) { result = 1; }
@@ -41,8 +41,8 @@ fn only_first_true_elif_is_executed() {
 }
 
 #[test]
-fn if_elif_else_implicit_ret() {
-  val test_fn = fn() {
+fn if_elif_else_implicit_ret {
+  val test_fn = fn {
     if (1 == 2) -> 1;
     elif (2 == 3) -> 2;
     else -> 3;
@@ -52,7 +52,7 @@ fn if_elif_else_implicit_ret() {
 }
 
 #[test] 
-fn or_shortcircuit_complex_left_is_true() {
+fn or_shortcircuit_complex_left_is_true {
   rw val x = nil;
   
   if (x is Nil || x is String || x > 0 || x < 1 ) {
@@ -63,7 +63,7 @@ fn or_shortcircuit_complex_left_is_true() {
 }
 
 #[test] 
-fn or_shortcircuit_left_is_true() {
+fn or_shortcircuit_left_is_true {
   rw val x = nil;
   
   if (x is Nil || x > 0) {
@@ -74,7 +74,7 @@ fn or_shortcircuit_left_is_true() {
 }
 
 #[test] 
-fn or_shortcircuit_right_is_true() {
+fn or_shortcircuit_right_is_true {
   rw val x = -1;
   
   if (x is Nil || x < 0) {
@@ -85,7 +85,7 @@ fn or_shortcircuit_right_is_true() {
 }
 
 #[test] 
-fn or_shortcircuit_complex_right_is_true() {
+fn or_shortcircuit_complex_right_is_true {
   rw val x = -1;
   
   if (x is Nil || (x is String || x < 0)) {
@@ -96,7 +96,7 @@ fn or_shortcircuit_complex_right_is_true() {
 }
 
 #[test] 
-fn or_shortcircuit_complex_else_branch() {
+fn or_shortcircuit_complex_else_branch {
   rw val x = -1;
   
   if (x is Nil || (x is String || x > 0)) {

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/013_extra_arguments.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/013_extra_arguments.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn xargs_formal_params() {
+fn xargs_formal_params {
   val f = fn(a, b, c) -> ...[0] + ...[1];
 
   assert.equal(
@@ -9,8 +9,8 @@ fn xargs_formal_params() {
 }
 
 #[test]
-fn xargs_no_formal_params() {
-  val f = fn() -> ...[0] + ...[1];
+fn xargs_no_formal_params {
+  val f = fn -> ...[0] + ...[1];
   
   assert.equal(
     f(2, 0.137),

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/014_nontrivial_tests.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/014_nontrivial_tests.vil
@@ -56,24 +56,24 @@ fn bubble_sort_array(arr) {
 }
 
 #[test] 
-fn fibonacci_recursive() {
+fn fibonacci_recursive {
   val result = fib_recursive(40);
   assert.equal(result, 102334155);
 }
 #[test]
-fn fibonacci_iterative() {
+fn fibonacci_iterative {
   val result = fib_iterative(41);
   assert.equal(result, 165580141);
 }
 
 #[test]
-fn tailrec_invoke() {
+fn tailrec_invoke {
   val result = fact_tailrec(10);
   assert.equal(result, 3628800);
 }
 
 #[test]
-fn bubblesort_table() {
+fn bubblesort_table {
   val a = { 4, 65, 2, -31, 0, 99, 2, 83, 782, 1 };
   
   // Tables are always passed by reference.
@@ -83,7 +83,7 @@ fn bubblesort_table() {
 }
 
 #[test]
-fn bubblesort_array() {
+fn bubblesort_array {
   val a = array { 4, 65, 2, -31, 0, 99, 2, 83, 782, 1 };
   
   // Arrays are always passed by reference.

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/016_scope.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/016_scope.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn out_of_scope_evaluates_to_global() {
+fn out_of_scope_evaluates_to_global {
   val a = 10;
   b = 33;
   
@@ -11,7 +11,7 @@ fn out_of_scope_evaluates_to_global() {
 }
 
 #[test]
-fn local_scope_hides_global_scope() {
+fn local_scope_hides_global_scope {
   a = "jp2gmd";
   
   val a = 21.37;
@@ -19,7 +19,7 @@ fn local_scope_hides_global_scope() {
 }
 
 #[test]
-fn mixed_local_and_global_scopes() {
+fn mixed_local_and_global_scopes {
   a = "jp2gmd"; rw val b = 2;
   
   {
@@ -38,7 +38,7 @@ fn mixed_local_and_global_scopes() {
 }
 
 #[test]
-fn variables_go_out_of_scope() {
+fn variables_go_out_of_scope {
   {
     val x = 10; 
     {

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/017_each_loop.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/017_each_loop.vil
@@ -1,5 +1,5 @@
 ﻿#[test]
-fn each_basic_table() {
+fn each_basic_table {
   val t = { x: 21.37, y: "haha funny number" };
 
   rw val tvar_1 = nil;
@@ -18,7 +18,7 @@ fn each_basic_table() {
 }
 
 #[test]
-fn each_basic_table_skip() {
+fn each_basic_table_skip {
   val t = { x: 21.37, y: 11.11, z: 44.51 };
 
   rw val tvar_1 = nil;
@@ -35,7 +35,7 @@ fn each_basic_table_skip() {
 }
 
 #[test]
-fn each_basic_table_break() {
+fn each_basic_table_break {
   val t = { x: 21.37, y: 11.11, z: 44.51 };
 
   rw val tvar_1 = nil;
@@ -51,8 +51,8 @@ fn each_basic_table_break() {
 }
 
 #[test]
-fn each_basic_table_ret() {
-  val f = fn() {
+fn each_basic_table_ret {
+  val f = fn {
     val t = { x: 21.37, y: 11.11, z: 44.51 };
     
     each (rw val key, value : t) {
@@ -67,7 +67,7 @@ fn each_basic_table_ret() {
 }
 
 #[test]
-fn each_kv_table() {
+fn each_kv_table {
   val t = { x: "21.37", y: "haha funny number" };
 
   rw val tvar_k1 = nil;
@@ -92,7 +92,7 @@ fn each_kv_table() {
 }
 
 #[test]
-fn each_kv_table_skip() {
+fn each_kv_table_skip {
   val t = { x: "21.37", y: "haha funny number", z: "11111111" };
 
   rw val tvar_k = nil;
@@ -112,7 +112,7 @@ fn each_kv_table_skip() {
 }
 
 #[test]
-fn each_kv_table_break() {
+fn each_kv_table_break {
   val t = { x: "21.37", y: "haha funny number", z: "11111111" };
 
   rw val tvar_k = nil;
@@ -131,8 +131,8 @@ fn each_kv_table_break() {
 }
 
 #[test]
-fn each_kv_table_ret() {
-  val f = fn() {
+fn each_kv_table_ret {
+  val f = fn {
     val t = { x: 21.37, y: 11.11, z: 44.51 };
     
     each (rw val key, value : t) {
@@ -147,7 +147,7 @@ fn each_kv_table_ret() {
 }
 
 #[test]
-fn each_val_only() {
+fn each_val_only {
   val t = { 10, 20, 30, 40 };
   
   each (rw val value : t) {

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/018_closures.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/018_closures.vil
@@ -5,31 +5,25 @@ fn generate_closure_with_parameter_value(x)
     -> (fn(a) -> a + x);
 
 #[test]
-fn basic_closure_parameter_hides_local() {
+fn basic_closure_parameter_hides_local {
   val a = 10;
-  
-  val f = fn(a) {
-    ret a;
-  };
+  val f = fn(a) -> a;
   
   val result = f(12);
   assert.equal(result, 12);
 }
 
 #[test]
-fn basic_closure_captures_local() {
+fn basic_closure_captures_local {
   val b = 10;
-  
-  val f = fn() {
-    ret b + 2;
-  };
+  val f = fn -> b + 2;
   
   val result = test_invocation(f);
   assert.equal(result, 12);
 }
 
 #[test]
-fn basic_closure_captures_parameter() {
+fn basic_closure_captures_parameter {
   val f = generate_closure_with_parameter_value(10);
   val result = f(2);
   
@@ -37,9 +31,9 @@ fn basic_closure_captures_parameter() {
 }
 
 #[test]
-fn nested_closure_captures_outside_local() {
+fn nested_closure_captures_outside_local {
   val a = 21;
-  val f = (fn() -> (fn() -> a + .37));
+  val f = (fn -> (fn -> a + .37));
   
   val result = f()();
   
@@ -47,12 +41,12 @@ fn nested_closure_captures_outside_local() {
 }
 
 #[test]
-fn nested_closure_captures_closure_local() {
+fn nested_closure_captures_closure_local {
   val a = 111;
   
-  val f = fn() {
+  val f = fn {
       val a = 21;
-      ret fn() { ret a + .37; };
+      ret fn -> a + .37;
   };
   
   val result = f()();
@@ -61,10 +55,10 @@ fn nested_closure_captures_closure_local() {
 }
 
 #[test]
-fn nested_closure_captures_closure_parameter() {
+fn nested_closure_captures_closure_parameter {
   val a = 111;
   val f = fn(a) {
-    ret fn() { ret a + .37; };
+    ret fn -> a + .37;
   };
   
   val result = f(21)();
@@ -73,12 +67,12 @@ fn nested_closure_captures_closure_parameter() {
 }
 
 #[test]
-fn extreme_closure_nesting() {
+fn extreme_closure_nesting {
   val a = 10;
   
   val result = test_invocation(fn(b) {
     val f = fn(c) {
-      ret fn() { ret a + b + c; };
+      ret fn -> a + b + c;
     };
     ret f(2);
   }(9)) + .37;
@@ -100,7 +94,7 @@ fn filter_table(t, predicate) {
 }
 
 #[test]
-fn predicate_anonymous_function() {
+fn predicate_anonymous_function {
     val t = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
     val t2 = filter_table(
         t, 
@@ -117,7 +111,7 @@ fn delay(ms) {
   ret 2.137;
 }
 
-fn spawn_yielding_closure() {
+fn spawn_yielding_closure {
   ret fn() {
     val start = time.stamp.ms;
     val retval = yield<delay>(500);
@@ -130,7 +124,7 @@ fn spawn_yielding_closure() {
 }
 
 #[test]
-fn yield_delay_from_closure() {
+fn yield_delay_from_closure {
   val f = spawn_yielding_closure();
   val r = yield<f>();
   
@@ -154,7 +148,7 @@ fn all(t, predicate) {
 }
 
 #[test]
-fn spawn_closures_in_loop() {
+fn spawn_closures_in_loop {
   val results = { };
   for (rw val i = 0; i < 11; i++) {
     results[i] = spawn_closure_for_loop(i)(1);
@@ -169,7 +163,7 @@ fn spawn_closures_in_loop() {
 }
 
 #[test]
-fn many_subchunks_capture_same_local_no_change() {
+fn many_subchunks_capture_same_local_no_change {
   val local_a = 10;
   
   val f1 = fn(x) -> local_a + x;
@@ -183,7 +177,7 @@ fn many_subchunks_capture_same_local_no_change() {
 }
 
 #[test]
-fn many_subchunks_capture_same_local_after_change() {
+fn many_subchunks_capture_same_local_after_change {
   rw val local_a = 11;
   val f1 = fn(x) -> local_a + x;
   
@@ -204,7 +198,7 @@ fn many_subchunks_capture_same_local_after_change() {
 fn invoke_func_out_of_scope(f) -> f();
 
 #[test]
-fn after_invocation_var_return() {
+fn after_invocation_var_return {
   val f = fn() -> 21.37;
   val res = f();
   val res2 = invoke_func_out_of_scope(f);
@@ -212,7 +206,7 @@ fn after_invocation_var_return() {
   assert.equal(res, res2);
 }
 
-fn make_counter() {
+fn make_counter {
   rw val counter = 0;
   
   ret fn() {
@@ -222,7 +216,7 @@ fn make_counter() {
 }
 
 #[test]
-fn internal_closure_state_is_preserved() {
+fn internal_closure_state_is_preserved {
   val counter = make_counter();
   rw val result = 0;
   
@@ -234,7 +228,7 @@ fn internal_closure_state_is_preserved() {
 }
 
 #[test]
-fn parameter_is_preserved() {
+fn parameter_is_preserved {
   val start_at = fn (x) {
     ret fn(y) -> x + y;
   };
@@ -249,7 +243,7 @@ fn parameter_is_preserved() {
 }
 
 #[test]
-fn closures_in_each() {
+fn closures_in_each {
   val result_data = { };
   val test_data = { 1, 2, 3, 4, 5 };
   
@@ -264,7 +258,7 @@ fn closures_in_each() {
 }
 
 #[test]
-fn modify_external_scope_closure() {
+fn modify_external_scope_closure {
   rw val result_a,
          result_b,
          result_c,

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/019_import.dofile.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/019_import.dofile.vil
@@ -1,7 +1,7 @@
 dofile("lib/test.vil");
 
 #[test]
-fn dofile_imported_funcs() {
+fn dofile_imported_funcs {
   val result = imported_add(10, 10) 
              + imported_sub(5, 0)
              + imported_mul(3, 3)

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/019_import.require.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/019_import.require.vil
@@ -1,7 +1,7 @@
 val test_module = require("test_module");
 
 #[test]
-fn module_function_invocation() {
+fn module_function_invocation {
   val result = test_module.add(2, 3)
              + test_module.sub(5, 1);
              

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/020_self.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/020_self.vil
@@ -1,5 +1,5 @@
 #[test]
-fn selfness_in_table() {
+fn selfness_in_table {
   val t = {
     f: self::fn(a, b) -> self.result = a + b
   };
@@ -11,7 +11,7 @@ fn selfness_in_table() {
 }
 
 #[test]
-fn self_fn_ret() {
+fn self_fn_ret {
   val t = { 
     func: self::fn(a, b) {
       self.result = a + b;
@@ -24,7 +24,7 @@ fn self_fn_ret() {
 }
 
 #[test]
-fn self_fn_state() {
+fn self_fn_state {
   val chair = {
     __quips: array {
       "The chair is perfectly fine. It'd be a shame if someone decided to test it.",
@@ -34,15 +34,15 @@ fn self_fn_state() {
     },
     leg_count: 4,
     
-    is_broken: self::fn() -> self.leg_count != 4,
-    get_status: self::fn() {
+    is_broken: self::fn -> self.leg_count != 4,
+    get_status: self::fn {
       if (self.leg_count == 4) -> self.__quips[0];
       elif (self.leg_count < 0) -> self.__quips[1];
       elif (self.leg_count < 4) -> self.__quips[2];
       elif (self.leg_count > 4) -> self.__quips[3];
     },
-    break_leg: self::fn() -> self.leg_count--,
-    add_leg: self::fn() -> self.leg_count++
+    break_leg: self::fn -> self.leg_count--,
+    add_leg: self::fn -> self.leg_count++
   };
   
   assert.equal(chair.leg_count, 4);
@@ -72,11 +72,11 @@ fn self_fn_state() {
 }
 
 #[test]
-fn self_referencing_self() {
+fn self_referencing_self {
   val t = {
     set: self::fn(v) -> self.__value = v,
-    get_self: self::fn() -> self,
-    create_new: self::fn() -> {
+    get_self: self::fn -> self,
+    create_new: self::fn -> {
       set: self::fn(v) {
         self.__value = v;
         ret self;
@@ -92,7 +92,7 @@ fn self_referencing_self() {
 }
 
 #[test]
-fn self_builder() {
+fn self_builder {
   val ThingBuilder = { new: self::fn(name) -> {
     __name: name,
     __class: nil,
@@ -114,10 +114,10 @@ fn self_builder() {
       ret self;
     },
     
-    get_name: self::fn() -> self.__name,
-    get_class: self::fn() -> self.__class,
-    get_description: self::fn() -> self.__desc,
-    get_purpose: self::fn() -> self.__purpose
+    get_name: self::fn -> self.__name,
+    get_class: self::fn -> self.__class,
+    get_description: self::fn -> self.__desc,
+    get_purpose: self::fn -> self.__purpose
   }};
   
   val chair = ThingBuilder::new("chair")

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/021_override.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/021_override.vil
@@ -3,7 +3,7 @@ Box = { new: self::fn(value) {
     __value: value,
     
     set_value: self::fn(value) -> self.__value = value,
-    get_value: self::fn() -> self.__value
+    get_value: self::fn -> self.__value
   };
   
   override(table)::__add(a, b) -> Box::new(a::get_value() + b::get_value());
@@ -68,7 +68,7 @@ Box = { new: self::fn(value) {
 }};
 
 #[test]
-fn add_override() {
+fn add_override {
   val objA = Box::new(10);
   val objB = Box::new(5);
   
@@ -79,7 +79,7 @@ fn add_override() {
 }
 
 #[test]
-fn sub_override() {
+fn sub_override {
   val objA = Box::new(10);
   val objB = Box::new(5);
   
@@ -90,7 +90,7 @@ fn sub_override() {
 }
 
 #[test]
-fn mul_override() {
+fn mul_override {
   val objA = Box::new(10);
   val objB = Box::new(5);
   
@@ -101,7 +101,7 @@ fn mul_override() {
 }
 
 #[test]
-fn div_override() {
+fn div_override {
   val objA = Box::new(10);
   val objB = Box::new(5);
   
@@ -112,7 +112,7 @@ fn div_override() {
 }
 
 #[test]
-fn mod_override() {
+fn mod_override {
   val objA = Box::new(10);
   val objB = Box::new(3);
   
@@ -123,7 +123,7 @@ fn mod_override() {
 }
 
 #[test]
-fn shl_override() {
+fn shl_override {
   val objA = Box::new(1);
   val objB = Box::new(4);
   
@@ -134,7 +134,7 @@ fn shl_override() {
 }
 
 #[test]
-fn shr_override() {
+fn shr_override {
   val objA = Box::new(16);
   val objB = Box::new(2);
   
@@ -145,7 +145,7 @@ fn shr_override() {
 }
 
 #[test]
-fn aneg_override() {
+fn aneg_override {
   val objA = Box::new(21.37);
   val result = -objA;
   
@@ -154,7 +154,7 @@ fn aneg_override() {
 }
 
 #[test]
-fn inc_override_post() {
+fn inc_override_post {
   rw val obj = Box::new(10);
   val result = obj++;
   
@@ -164,7 +164,7 @@ fn inc_override_post() {
 }
 
 #[test]
-fn inc_override_pre() {
+fn inc_override_pre {
   rw val obj = Box::new(10);
   val result = ++obj;
   
@@ -174,7 +174,7 @@ fn inc_override_pre() {
 }
 
 #[test]
-fn dec_override_post() {
+fn dec_override_post {
   rw val obj = Box::new(10);
   val result = obj--;
   
@@ -184,7 +184,7 @@ fn dec_override_post() {
 }
 
 #[test]
-fn dec_override_pre() {
+fn dec_override_pre {
   rw val obj = Box::new(10);
   val result = --obj;
   
@@ -194,7 +194,7 @@ fn dec_override_pre() {
 }
 
 #[test]
-fn lnot_override() {
+fn lnot_override {
   val obj = Box::new(false);
   val result = !obj;
   
@@ -204,7 +204,7 @@ fn lnot_override() {
 }
 
 #[test]
-fn lor_override() {
+fn lor_override {
   val objA = Box::new(false);
   val objB = Box::new(true);
   val result = objA || objB;
@@ -215,7 +215,7 @@ fn lor_override() {
 }
 
 #[test]
-fn land_override() {
+fn land_override {
   val objA = Box::new(false);
   val objB = Box::new(true);
   val result = objA && objB;
@@ -226,7 +226,7 @@ fn land_override() {
 }
 
 #[test]
-fn bor_override() {
+fn bor_override {
   val objA = Box::new(0xF000);
   val objB = Box::new(0x000F);
   val result = objA | objB;
@@ -237,7 +237,7 @@ fn bor_override() {
 }
 
 #[test]
-fn bxor_override() {
+fn bxor_override {
   val objA = Box::new(0xF0F0);
   val objB = Box::new(0xFFFF);
   val result = objA ^ objB;
@@ -248,7 +248,7 @@ fn bxor_override() {
 }
 
 #[test]
-fn band_override() {
+fn band_override {
   val objA = Box::new(0xFFFF);
   val objB = Box::new(0x0FF0);
   val result = objA & objB;
@@ -259,7 +259,7 @@ fn band_override() {
 }
 
 #[test]
-fn bnot_override() {
+fn bnot_override {
   val obj = Box::new(0x0FFF);
   val result = ~obj;
   
@@ -272,7 +272,7 @@ fn bnot_override() {
 }
 
 #[test]
-fn deq_override() {
+fn deq_override {
   val objA = Box::new({1, 2, 3, { 1, 2, 3 }});
   val objB = Box::new({1, 2, 3, { 1, 2, 3 }});
   val result = objA <==> objB;
@@ -283,7 +283,7 @@ fn deq_override() {
 }
 
 #[test]
-fn dne_override() {
+fn dne_override {
   val objA = Box::new({1, 2, 3, { 1, 2, 3 }});
   val objB = Box::new({1, 2, 3, { 1, 21.37, 3 }});
   val result = objA <!=> objB;
@@ -294,7 +294,7 @@ fn dne_override() {
 }
 
 #[test]
-fn eq_override_byval() {
+fn eq_override_byval {
   val objA = Box::new(21.37);
   val objB = Box::new(21.37);
   val result = objA == objB;
@@ -305,7 +305,7 @@ fn eq_override_byval() {
 }
 
 #[test]
-fn eq_override_byref() {
+fn eq_override_byref {
   val t = { 1, 2, 3 };
   
   val objA = Box::new(t);
@@ -318,7 +318,7 @@ fn eq_override_byref() {
 }
 
 #[test]
-fn ne_override_byval() {
+fn ne_override_byval {
   val objA = Box::new(12.34);
   val objB = Box::new(21.37);
   val result = objA != objB;
@@ -329,7 +329,7 @@ fn ne_override_byval() {
 }
 
 #[test]
-fn ne_override_byref() {
+fn ne_override_byref {
   val t1 = { 1, 2 };
   val t2 = { 1, 2 };
   
@@ -343,7 +343,7 @@ fn ne_override_byref() {
 }
 
 #[test]
-fn gt_override_gt() {
+fn gt_override_gt {
   val objA = Box::new(37);
   val objB = Box::new(21);
   val result = objA > objB;
@@ -354,7 +354,7 @@ fn gt_override_gt() {
 }
 
 #[test]
-fn gt_override_eq() {
+fn gt_override_eq {
   val objA = Box::new(21);
   val objB = Box::new(21);
   val result = objA > objB;
@@ -365,7 +365,7 @@ fn gt_override_eq() {
 }
 
 #[test]
-fn lt_override_lt() {
+fn lt_override_lt {
   val objA = Box::new(21);
   val objB = Box::new(37);
   val result = objA < objB;
@@ -376,7 +376,7 @@ fn lt_override_lt() {
 }
 
 #[test]
-fn lt_override_eq() {
+fn lt_override_eq {
   val objA = Box::new(37);
   val objB = Box::new(37);
   val result = objA < objB;
@@ -387,7 +387,7 @@ fn lt_override_eq() {
 }
 
 #[test]
-fn gte_override_gt() {
+fn gte_override_gt {
   val objA = Box::new(37);
   val objB = Box::new(21);
   val result = objA >= objB;
@@ -398,7 +398,7 @@ fn gte_override_gt() {
 }
 
 #[test]
-fn gte_override_eq() {
+fn gte_override_eq {
   val objA = Box::new(37);
   val objB = Box::new(37);
   val result = objA >= objB;
@@ -409,7 +409,7 @@ fn gte_override_eq() {
 }
 
 #[test]
-fn lte_override_gt() {
+fn lte_override_gt {
   val objA = Box::new(21);
   val objB = Box::new(37);
   val result = objA <= objB;
@@ -420,7 +420,7 @@ fn lte_override_gt() {
 }
 
 #[test]
-fn lte_override_eq() {
+fn lte_override_eq {
   val objA = Box::new(37);
   val objB = Box::new(37);
   val result = objA >= objB;
@@ -431,7 +431,7 @@ fn lte_override_eq() {
 }
 
 #[test]
-fn len_override() {
+fn len_override {
   val obj = Box::new(Nil);
   val result = #obj;
   
@@ -440,7 +440,7 @@ fn len_override() {
 }
 
 #[test]
-fn tonum_override() {
+fn tonum_override {
   val obj = Box::new(11.11);
   val result = $obj;
   
@@ -449,7 +449,7 @@ fn tonum_override() {
 }
 
 #[test]
-fn tostr_override() {
+fn tostr_override {
   val obj = Box::new(11.11);
   val result = @obj;
   
@@ -458,7 +458,7 @@ fn tostr_override() {
 }
 
 #[test]
-fn invoke_override() {
+fn invoke_override {
   val obj = Box::new(2137);
   val result = obj(10, 20, 30);
   
@@ -467,7 +467,7 @@ fn invoke_override() {
 }
 
 #[test]
-fn set_override() { 
+fn set_override { 
   val obj = Box::new(2137);
   val resultA = obj["jp2"] = 222;
   val resultB = obj["test"] = 123;
@@ -480,7 +480,7 @@ fn set_override() {
 }
 
 #[test]
-fn get_override() {
+fn get_override {
   val obj = Box::new(2137);
   obj.lalala = 10;
   
@@ -492,7 +492,7 @@ fn get_override() {
 }
 
 #[test]
-fn exists_override() {
+fn exists_override {
   val obj = Box::new(2137);
   obj["11"] = 22;
   

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/022_by_expr.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/022_by_expr.vil
@@ -1,5 +1,5 @@
 #[test]
-fn valref_qualifier_basic_with_else_branch() {
+fn valref_qualifier_basic_with_else_branch {
   val value = 123;
   
   val result = by value {
@@ -13,7 +13,7 @@ fn valref_qualifier_basic_with_else_branch() {
 }
 
 #[test]
-fn valref_qualifier_basic_without_else_branch() {
+fn valref_qualifier_basic_without_else_branch {
   val value = 666;
   
   val result = by value {
@@ -26,7 +26,7 @@ fn valref_qualifier_basic_without_else_branch() {
 }
 
 #[test]
-fn valref_qualifier_as_part_of_expression() {
+fn valref_qualifier_as_part_of_expression {
   val value = 456;
   
   val result = by value {
@@ -40,7 +40,7 @@ fn valref_qualifier_as_part_of_expression() {
 }
 
 #[test]
-fn simple_expr_qualifier_basic_with_else_branch() {
+fn simple_expr_qualifier_basic_with_else_branch {
   val result = by (400 + 56) {
     222 -> 1234,
     123 -> "hhhhh",
@@ -52,7 +52,7 @@ fn simple_expr_qualifier_basic_with_else_branch() {
 }
 
 #[test]
-fn complex_expr_qualifier_as_part_of_expression() {
+fn complex_expr_qualifier_as_part_of_expression {
   loc fn test(a, b = 15) -> a + b;
   val table = { 10, 20, 30 };
   
@@ -67,7 +67,7 @@ fn complex_expr_qualifier_as_part_of_expression() {
 }
 
 #[test]
-fn qualifier_is_table() {
+fn qualifier_is_table {
   val position = { x: 21, y: 37 };
   
   val result = by position {
@@ -82,7 +82,7 @@ fn qualifier_is_table() {
 }
 
 #[test]
-fn qualifier_is_type() {
+fn qualifier_is_type {
   loc fn get_type_msg(v) -> by typeof(v) {
     Nil -> "It's a Nil!",
     Number -> "It's a Number!",

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/023_try.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/023_try.vil
@@ -1,5 +1,5 @@
 #[test]
-fn try_catch_ok() {
+fn try_catch_ok {
   rw val result;
 
   try {
@@ -17,7 +17,7 @@ loc fn throwing_inner(value) {
 }
 
 #[test]
-fn try_invoked_throws() {
+fn try_invoked_throws {
   rw val result;
 
   try {
@@ -31,7 +31,7 @@ fn try_invoked_throws() {
 }
 
 #[test]
-fn nested_try_blocks_innermost() {
+fn nested_try_blocks_innermost {
   rw val result;
 
   try {
@@ -46,7 +46,7 @@ fn nested_try_blocks_innermost() {
 }
 
 #[test]
-fn nested_try_blocks_rethrow() {
+fn nested_try_blocks_rethrow {
   rw val result;
 
   try { 
@@ -72,13 +72,13 @@ loc fn is_valid_type(value) {
 }
 
 #[test]
-fn try_invoked_ret_differs() {
+fn try_invoked_ret_differs {
   assert.equal(is_valid_type(123), false);
   assert.equal(is_valid_type("meow"), true);
 }
 
 #[test]
-fn try_native_throws() {
+fn try_native_throws {
   rw val result;
 
   try {
@@ -91,7 +91,7 @@ fn try_native_throws() {
 }
 
 #[test]
-fn try_require() { 
+fn try_require { 
   rw val result = "hiii";
 
   try { result = require("doesnt_exist"); }
@@ -115,7 +115,7 @@ loc fn throwing_by(value) -> by typeof(value) {
 };
 
 #[test]
-fn try_by() {
+fn try_by {
   rw val result;
   
   try {
@@ -129,7 +129,7 @@ fn try_by() {
 }
 
 #[test]
-fn try_error_userdata_only() {
+fn try_error_userdata_only {
   rw val result;
   
   try {
@@ -143,7 +143,7 @@ fn try_error_userdata_only() {
 }
 
 #[test]
-fn try_error_implicit_message_only() {
+fn try_error_implicit_message_only {
   rw val result;
   
   try {
@@ -157,7 +157,7 @@ fn try_error_implicit_message_only() {
 }
 
 #[test]
-fn try_error_implicit_message_and_userdata() {
+fn try_error_implicit_message_and_userdata {
   rw val result;
   rw val result2;
    

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/024_fn_targeted.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/024_fn_targeted.vil
@@ -35,7 +35,7 @@ override(TestClass = {})::__invoke(instance_name) {
 }
 
 #[test]
-fn targeted_fn_self_invocations() {
+fn targeted_fn_self_invocations {
   val instance = TestClass("instance_name_uwu");
   
   assert.equal(instance.__name, "instance_name_uwu");
@@ -75,7 +75,7 @@ fn targeted_fn_self_invocations() {
 }
 
 #[test]
-fn targeted_fn_in_local() {
+fn targeted_fn_in_local {
   val Object = {};
   
   loc fn Object::meow(x) {
@@ -90,7 +90,7 @@ fn targeted_fn_in_local() {
 }
 
 #[test]
-fn targeted_fn_nested() {
+fn targeted_fn_nested {
   val Object = {};
   
   loc fn Object::thing(x) {
@@ -109,7 +109,7 @@ fn targeted_fn_nested() {
 }
 
 #[test]
-fn targeted_fn_conditional() {
+fn targeted_fn_conditional {
   val Object = {};
   
   if (false) {
@@ -124,7 +124,7 @@ fn targeted_fn_conditional() {
 }
 
 #[test]
-fn targeted_fn_multiscope() {
+fn targeted_fn_multiscope {
   {
     val Object = {};
   
@@ -153,7 +153,7 @@ fn targeted_fn_multiscope() {
 }
 
 #[test]
-fn targeted_fn_self() {
+fn targeted_fn_self {
   val Object = {};
   
   override(Object)::__invoke(a1) {

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/099_yield.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/099_yield.vil
@@ -7,7 +7,7 @@ fn delay(ms) {
   ret 2.137;
 }
 
-fn dep_a() {
+fn dep_a {
   if (glob_a--) {
     yield<delay>(10);
     yield<dep_b>();
@@ -16,7 +16,7 @@ fn dep_a() {
   ret 213.7;
 }
 
-fn dep_b() {
+fn dep_b {
   if (glob_b--) {
     yield<delay>(10);
     yield<dep_a>(2000);
@@ -28,13 +28,13 @@ fn dep_b() {
 fn ref_dep_b() -> dep_b;
 
 #[test]
-fn yield_simple() {
+fn yield_simple {
   val result = yield<jp2gmd>(1, 21, 3);
   assert.equal(result, 21.37);
 }
 
 #[test]
-fn yield_delay() {
+fn yield_delay {
   val start = time.stamp.ms;
   val retval = yield<delay>(1000);
   
@@ -43,7 +43,7 @@ fn yield_delay() {
 }
 
 #[test]
-fn yield_interdependent() {
+fn yield_interdependent {
   glob_a = 3;
   glob_b = 3;
   val a = yield<dep_a>();
@@ -57,19 +57,19 @@ fn yield_interdependent() {
 }
 
 #[test]
-fn yield_identifier() -> assert.equal(
+fn yield_identifier -> assert.equal(
   yield<jp2gmd>(1, 21, 3),
   21.37
 );
 
 #[test]
-fn yield_expression_identifier() -> assert.equal(
+fn yield_expression_identifier -> assert.equal(
   yield<[jp2gmd]>(1, 21, 3),
   21.37
 );
 
 #[test]
-fn yield_expression() -> assert.equal(
+fn yield_expression -> assert.equal(
   yield<[ref_dep_b()]>(),
   0.2137
 );


### PR DESCRIPTION
Before:
```
fn no_params() { }
fn no_params_expr() -> nil;

val t = { f: self::fn() -> nil; };
loc fn t::f2() -> nil;

override(t)::__invoke() -> 123;
```

After:
```
fn no_params { }
fn no_params_expr -> nil;

val t = { f: self::fn -> nil; };
loc fn t::f2 -> nil;

override(t)::__invoke -> 123;
```