### PR TITLE
Optional try-catch handler local and reparenting improvement.

### DIFF
--- a/Core/EVIL.Grammar/AST/Base/AstNode.cs
+++ b/Core/EVIL.Grammar/AST/Base/AstNode.cs
@@ -32,7 +32,7 @@ namespace EVIL.Grammar.AST.Base
             }
         }
 
-        protected void Reparent(IEnumerable<AstNode> nodes) 
+        protected void Reparent(IEnumerable<AstNode?> nodes)
             => Reparent(nodes.ToArray());
     }
 }

--- a/Core/EVIL.Grammar/AST/Base/AstNode.cs
+++ b/Core/EVIL.Grammar/AST/Base/AstNode.cs
@@ -21,10 +21,15 @@ namespace EVIL.Grammar.AST.Base
             return (this as T)!;
         }
         
-        protected void Reparent(params AstNode[] nodes)
+        protected void Reparent(params AstNode?[] nodes)
         {
             for (var i = 0; i < nodes.Length; i++)
-                nodes[i].Parent = this;
+            {
+                if (nodes[i] != null)
+                {
+                    nodes[i]!.Parent = this;
+                }
+            }
         }
 
         protected void Reparent(IEnumerable<AstNode> nodes) 

--- a/Core/EVIL.Grammar/AST/Expressions/ArrayExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/ArrayExpression.cs
@@ -13,7 +13,8 @@ namespace EVIL.Grammar.AST.Expressions
             SizeExpression = sizeExpression;
             Initializers = initializers;
             
-            Reparent(initializers);
+            Reparent(SizeExpression);
+            Reparent(Initializers);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Expressions/ByExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/ByExpression.cs
@@ -7,7 +7,6 @@ namespace EVIL.Grammar.AST.Expressions
     public class ByExpression : Expression
     {
         public Expression Qualifier { get; }
-        
         public List<ByArmNode> Arms { get; }
         public AstNode? ElseArm { get; }
 
@@ -19,11 +18,7 @@ namespace EVIL.Grammar.AST.Expressions
 
             Reparent(Qualifier);
             Reparent(Arms);
-
-            if (ElseArm != null)
-            {
-                Reparent(ElseArm);
-            }
+            Reparent(ElseArm);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Expressions/ErrorExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/ErrorExpression.cs
@@ -13,15 +13,8 @@ namespace EVIL.Grammar.AST.Expressions
             ImplicitMessageConstant = implicitMessageConstant;
             UserDataTable = userDataTable;
 
-            if (ImplicitMessageConstant != null)
-            {
-                Reparent(ImplicitMessageConstant);
-            }
-
-            if (UserDataTable != null)
-            {
-                Reparent(UserDataTable);
-            }
+            Reparent(ImplicitMessageConstant);
+            Reparent(UserDataTable);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Expressions/FnExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/FnExpression.cs
@@ -15,11 +15,7 @@ namespace EVIL.Grammar.AST.Expressions
             ParameterList = parameterList;
             Statement = statement;
 
-            if (ParameterList != null)
-            {
-                Reparent(ParameterList);
-            }
-
+            Reparent(ParameterList);
             Reparent(Statement);
         }
     }

--- a/Core/EVIL.Grammar/AST/Expressions/SelfFnExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/SelfFnExpression.cs
@@ -15,12 +15,8 @@ namespace EVIL.Grammar.AST.Expressions
         {
             ParameterList = parameterList;
             Statement = statement;
-
-            if (ParameterList != null)
-            {
-                Reparent(ParameterList);
-            }
-
+            
+            Reparent(ParameterList);
             Reparent(Statement);
         }
     }

--- a/Core/EVIL.Grammar/AST/Expressions/TableExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/TableExpression.cs
@@ -13,8 +13,7 @@ namespace EVIL.Grammar.AST.Expressions
             Initializers = initializers;
             Keyed = keyed;
 
-            for (var i = 0; i < Initializers.Count; i++)
-                Reparent(Initializers[i]);
+            Reparent(Initializers);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Miscellaneous/AttributeNode.cs
+++ b/Core/EVIL.Grammar/AST/Miscellaneous/AttributeNode.cs
@@ -20,7 +20,7 @@ namespace EVIL.Grammar.AST.Miscellaneous
             Properties = properties;
 
             Reparent(Identifier);
-            Reparent(values);
+            Reparent(Values);
             Reparent(Properties.Keys);
             Reparent(Properties.Values);
         }

--- a/Core/EVIL.Grammar/AST/Miscellaneous/ParameterNode.cs
+++ b/Core/EVIL.Grammar/AST/Miscellaneous/ParameterNode.cs
@@ -16,9 +16,7 @@ namespace EVIL.Grammar.AST.Miscellaneous
             Initializer = initializer;
 
             Reparent(Identifier);
-            
-            if (Initializer != null)
-                Reparent(Initializer);
+            Reparent(Initializer);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Statements/BlockStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/BlockStatement.cs
@@ -10,11 +10,7 @@ namespace EVIL.Grammar.AST.Statements
         public BlockStatement(List<Statement> statements)
         {
             Statements = statements;
-
-            for (var i = 0; i < statements.Count; i++)
-            {
-                Reparent(statements[i]);
-            }
+            Reparent(Statements);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Statements/EachStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/EachStatement.cs
@@ -23,10 +23,7 @@ namespace EVIL.Grammar.AST.Statements
             Statement = statement;
 
             Reparent(KeyIdentifier);
-
-            if (ValueIdentifier != null)
-                Reparent(ValueIdentifier);
-            
+            Reparent(ValueIdentifier);
             Reparent(Iterable, Statement);
         }
     }

--- a/Core/EVIL.Grammar/AST/Statements/FnStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/FnStatement.cs
@@ -26,12 +26,7 @@ namespace EVIL.Grammar.AST.Statements.TopLevel
             IsLocalDefintion = isLocalDefintion;
 
             Reparent(Identifier);
-
-            if (ParameterList != null)
-            {
-                Reparent(ParameterList);
-            }
-
+            Reparent(ParameterList);
             Reparent(Statement);
             Reparent(Attributes);
         }

--- a/Core/EVIL.Grammar/AST/Statements/FnTargetedStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/FnTargetedStatement.cs
@@ -12,6 +12,7 @@ namespace EVIL.Grammar.AST.Statements
         public ParameterList? ParameterList { get; }
         public Statement Statement { get; }
         public List<AttributeNode> Attributes { get; }
+
         public bool IsSelfTargeting => PrimaryTarget is SelfExpression;
         
         public FnTargetedStatement(
@@ -29,12 +30,7 @@ namespace EVIL.Grammar.AST.Statements
 
             Reparent(PrimaryTarget);
             Reparent(SecondaryIdentifier);
-
-            if (ParameterList != null)
-            {
-                Reparent(ParameterList);
-            }
-
+            Reparent(ParameterList);
             Reparent(Statement);
             Reparent(Attributes);
         }

--- a/Core/EVIL.Grammar/AST/Statements/OverrideStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/OverrideStatement.cs
@@ -24,12 +24,7 @@ namespace EVIL.Grammar.AST.Statements
             Statement = statement;
             
             Reparent(Target);
-
-            if (ParameterList != null)
-            {
-                Reparent(ParameterList);
-            }
-
+            Reparent(ParameterList);
             Reparent(Statement);
         }
     }

--- a/Core/EVIL.Grammar/AST/Statements/RetStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/RetStatement.cs
@@ -9,11 +9,7 @@ namespace EVIL.Grammar.AST.Statements
         public RetStatement(Expression? expression)
         {
             Expression = expression;
-
-            if (Expression != null)
-            {
-                Reparent(Expression);
-            }
+            Reparent(Expression);
         }
     }
 }

--- a/Core/EVIL.Grammar/AST/Statements/TryStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/TryStatement.cs
@@ -6,7 +6,6 @@ namespace EVIL.Grammar.AST.Statements
     public class TryStatement : Statement
     {
         public Statement InnerStatement { get; }
-
         public IdentifierNode? HandlerExceptionLocal { get; }
         public Statement HandlerStatement { get; }
 

--- a/Core/EVIL.Grammar/AST/Statements/TryStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/TryStatement.cs
@@ -7,10 +7,13 @@ namespace EVIL.Grammar.AST.Statements
     {
         public Statement InnerStatement { get; }
 
-        public IdentifierNode HandlerExceptionLocal { get; }
+        public IdentifierNode? HandlerExceptionLocal { get; }
         public Statement HandlerStatement { get; }
 
-        public TryStatement(Statement innerStatement, IdentifierNode handlerExceptionLocal, Statement handlerStatement)
+        public TryStatement(
+            Statement innerStatement,
+            IdentifierNode? handlerExceptionLocal, 
+            Statement handlerStatement)
         {
             InnerStatement = innerStatement;
             HandlerExceptionLocal = handlerExceptionLocal;

--- a/Core/EVIL.Grammar/AST/Statements/ValStatement.cs
+++ b/Core/EVIL.Grammar/AST/Statements/ValStatement.cs
@@ -17,12 +17,7 @@ namespace EVIL.Grammar.AST.Statements
             ReadWrite = readWrite;
 
             Reparent(Definitions.Keys);
-            
-            foreach (var kvp in Definitions)
-            {
-                if (kvp.Value != null)
-                    Reparent(kvp.Value);
-            }
+            Reparent(Definitions.Values);
         }
     }
 }

--- a/Core/EVIL.Grammar/EVIL.Grammar.csproj
+++ b/Core/EVIL.Grammar/EVIL.Grammar.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>11.0</LangVersion>
         
-        <Version>3.4.0</Version>
+        <Version>3.5.0</Version>
         <AssemblyName>EVIL.Grammar</AssemblyName>
         <AssemblyTitle>EVIL.Grammar</AssemblyTitle>
     </PropertyGroup>

--- a/Core/EVIL.Grammar/Parsing/Statements/Parser.TryStatement.cs
+++ b/Core/EVIL.Grammar/Parsing/Statements/Parser.TryStatement.cs
@@ -1,3 +1,4 @@
+using EVIL.Grammar.AST.Miscellaneous;
 using EVIL.Grammar.AST.Statements;
 using EVIL.Lexical;
 
@@ -10,9 +11,15 @@ namespace EVIL.Grammar.Parsing
             var (line, col) = Match(Token.Try);
             var protectedStatement = BlockStatement();
             Match(Token.Catch);
-            Match(Token.LParenthesis);
-            var exceptionObjectIdentifier = Identifier();
-            Match(Token.RParenthesis);
+
+            IdentifierNode? exceptionObjectIdentifier = null;
+            if (CurrentToken == Token.LParenthesis)
+            {
+                Match(Token.LParenthesis);
+                exceptionObjectIdentifier = Identifier();
+                Match(Token.RParenthesis);
+            }
+
             var handlerStatement = BlockStatement();
 
             return new TryStatement(

--- a/VirtualMachine/Ceres/Ceres.csproj
+++ b/VirtualMachine/Ceres/Ceres.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <LangVersion>11.0</LangVersion>
     
-    <Version>5.3.1</Version>
+    <Version>5.4.0</Version>
     <AssemblyName>Ceres</AssemblyName>
     <AssemblyTitle>Ceres</AssemblyTitle>
     

--- a/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.Try.cs
+++ b/VirtualMachine/Ceres/TranslationEngine/Compiler.Statement.Try.cs
@@ -22,17 +22,24 @@ namespace Ceres.TranslationEngine
             InNewLocalScopeDo(() =>
             {
                 Chunk.CodeGenerator.Emit(OpCode.LEAVE);
-                
-                CurrentScope.DefineLocal(
-                    tryStatement.HandlerExceptionLocal.Name,
-                    Chunk.AllocateLocal(),
-                    false,
-                    tryStatement.HandlerExceptionLocal.Line,
-                    tryStatement.HandlerExceptionLocal.Column
-                );
 
-                
-                EmitVarSet(tryStatement.HandlerExceptionLocal.Name);
+                if (tryStatement.HandlerExceptionLocal != null)
+                {
+                    CurrentScope.DefineLocal(
+                        tryStatement.HandlerExceptionLocal.Name,
+                        Chunk.AllocateLocal(),
+                        false,
+                        tryStatement.HandlerExceptionLocal.Line,
+                        tryStatement.HandlerExceptionLocal.Column
+                    );
+                    
+                    EmitVarSet(tryStatement.HandlerExceptionLocal.Name);
+                }
+                else
+                {
+                    Chunk.CodeGenerator.Emit(OpCode.POP);
+                }
+
                 Visit(tryStatement.HandlerStatement);
             });
 

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/023_try.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/023_try.vil
@@ -176,7 +176,7 @@ fn try_error_implicit_message_and_userdata {
   assert.equal(result2, "meow");
 }
 
-#[test;disasm("always")]
+#[test]
 fn try_no_local() {
   rw val caught = false;
   

--- a/VirtualMachine/Tests/Ceres.LanguageTests/tests/023_try.vil
+++ b/VirtualMachine/Tests/Ceres.LanguageTests/tests/023_try.vil
@@ -176,3 +176,17 @@ fn try_error_implicit_message_and_userdata {
   assert.equal(result2, "meow");
 }
 
+#[test;disasm("always")]
+fn try_no_local() {
+  rw val caught = false;
+  
+  try {
+    try {
+      try {
+        throw error("aaaa");
+      } catch (e) { throw e; }
+    } catch (e) { throw e; }
+  } catch { caught = true; }
+  
+  assert(caught);
+}


### PR DESCRIPTION
Before:
```
try {
 // ...
} catch (e) { /* (e) was mandatory */
 // ...
}
```

After:
```
try {
 // ...
} catch { /* Omitting catch parameter is now legal. */
 // ...
}