### PR TITLE
Table expansion expression

### DIFF
--- a/Core/EVIL.Grammar/AST/Expressions/WithExpression.cs
+++ b/Core/EVIL.Grammar/AST/Expressions/WithExpression.cs
@@ -1,0 +1,18 @@
+﻿using EVIL.Grammar.AST.Base;
+
+namespace EVIL.Grammar.AST.Expressions
+{
+    public class WithExpression : Expression
+    {
+        public Expression BaseExpression { get; }
+        public TableExpression TableExpansionExpression { get; }
+
+        public WithExpression(Expression baseExpression, TableExpression tableExpansionExpression)
+        {
+            BaseExpression = baseExpression;
+            TableExpansionExpression = tableExpansionExpression;
+
+            Reparent(BaseExpression, TableExpansionExpression);
+        }
+    }
+}

--- a/Core/EVIL.Grammar/EVIL.Grammar.csproj
+++ b/Core/EVIL.Grammar/EVIL.Grammar.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
-    <Version>4.4.0</Version>
+    <Version>4.5.0</Version>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.ByExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.ByExpression.cs
@@ -1,131 +1,125 @@
+﻿namespace EVIL.Grammar.Parsing;
+
 using System.Collections.Generic;
 using EVIL.Grammar.AST.Base;
 using EVIL.Grammar.AST.Expressions;
 using EVIL.Grammar.AST.Miscellaneous;
 using EVIL.Lexical;
 
-namespace EVIL.Grammar.Parsing
+public partial class Parser
 {
-    public partial class Parser
+    private ByExpression ByExpression()
     {
-        private Expression ByExpression()
+        var (line, col) = Match(Token.By);
+
+        var qualifier = AssignmentExpression();
+        Match(Token.LBrace);
+
+        var arms = new List<ByArmNode>();
+        AstNode? elseArm = null;
+
+        while (true)
         {
-            if (CurrentToken.Type == TokenType.By)
+            if (CurrentToken.Type == TokenType.EOF)
             {
-                var (line, col) = Match(Token.By);
+                throw new ParserException(
+                    "Unexpected EOF in a by-expression.",
+                    (CurrentToken.Line, CurrentToken.Column)
+                );
+            }
 
-                var qualifier = AssignmentExpression();
-                Match(Token.LBrace);
+            var (armLine, armCol) = (CurrentToken.Line, CurrentToken.Column);
 
-                var arms = new List<ByArmNode>();
-                AstNode? elseArm = null;
-                
-                while (true)
+            if (CurrentToken.Type == TokenType.RBrace)
+            {
+                if (arms.Count == 0)
                 {
-                    if (CurrentToken.Type == TokenType.EOF)
-                    {
-                        throw new ParserException(
-                            "Unexpected EOF in a by-expression.",
-                            (CurrentToken.Line, CurrentToken.Column)
-                        );
-                    }
+                    throw new ParserException(
+                        "Empty by-expressions are not allowed.",
+                        (line, col)
+                    );
+                }
+            }
 
-                    var (armLine, armCol) = (CurrentToken.Line, CurrentToken.Column);
-                    
-                    if (CurrentToken.Type == TokenType.RBrace)
-                    {
-                        if (arms.Count == 0)
-                        {
-                            throw new ParserException(
-                                "Empty by-expressions are not allowed.",
-                                (line, col)
-                            );
-                        }
-                    }
-
-                    if (CurrentToken.Type == TokenType.Else)
-                    {
-                        if (arms.Count == 0)
-                        {
-                            throw new ParserException(
-                                "'else' is illegal with no selector arms specified.",
-                                (armLine, armCol)
-                            );
-                        }
-                        
-                        Match(Token.Else);
-                        Match(Token.Colon);
-
-                        if (CurrentToken.Type == TokenType.Throw)
-                        {
-                            elseArm = ThrowStatement();
-                        }
-                        else
-                        {
-                            elseArm = AssignmentExpression();
-                        }
-
-
-                        if (CurrentToken.Type != TokenType.RBrace)
-                        {
-                            throw new ParserException(
-                                "'else' arm must be specified at the end of selector list.",
-                                (armLine, armCol)
-                            );
-                        }
-
-                        break;
-                    }
-                    else
-                    {
-                        var selector = AssignmentExpression();
-                        var deepEquality = false;
-                        
-                        if (CurrentToken.Type == TokenType.RightArrow)
-                        {
-                            Match(Token.RightArrow);
-                            deepEquality = false;
-                        }
-                        else if (CurrentToken.Type == TokenType.Associate)
-                        {
-                            Match(Token.Associate);
-                            deepEquality = true;
-                        }
-                        else
-                        {
-                            throw new ParserException(
-                                $"Expected '->' or '=>', found '{CurrentToken.Value}'.",
-                                (CurrentToken.Line, CurrentToken.Column)
-                            );
-                        }
-
-                        AstNode valueArm;
-                        if (CurrentToken.Type == TokenType.Throw)
-                        {
-                            valueArm = ThrowStatement();
-                        }
-                        else
-                        {
-                            valueArm = AssignmentExpression();
-                        }
-
-                        arms.Add(new ByArmNode(selector, valueArm, deepEquality) { Line = armLine, Column = armCol });
-                    }
-                    
-                    if (CurrentToken.Type == TokenType.RBrace)
-                    {
-                        break;
-                    }
-                    
-                    Match(Token.Comma);
+            if (CurrentToken.Type == TokenType.Else)
+            {
+                if (arms.Count == 0)
+                {
+                    throw new ParserException(
+                        "'else' is illegal with no selector arms specified.",
+                        (armLine, armCol)
+                    );
                 }
 
-                Match(Token.RBrace);
-                
-                return new ByExpression(qualifier, arms, elseArm) { Line = line, Column = col };
+                Match(Token.Else);
+                Match(Token.Colon);
+
+                if (CurrentToken.Type == TokenType.Throw)
+                {
+                    elseArm = ThrowStatement();
+                }
+                else
+                {
+                    elseArm = AssignmentExpression();
+                }
+
+
+                if (CurrentToken.Type != TokenType.RBrace)
+                {
+                    throw new ParserException(
+                        "'else' arm must be specified at the end of selector list.",
+                        (armLine, armCol)
+                    );
+                }
+
+                break;
             }
-            
-            return PrefixExpression();
+            else
+            {
+                var selector = AssignmentExpression();
+                var deepEquality = false;
+
+                if (CurrentToken.Type == TokenType.RightArrow)
+                {
+                    Match(Token.RightArrow);
+                    deepEquality = false;
+                }
+                else if (CurrentToken.Type == TokenType.Associate)
+                {
+                    Match(Token.Associate);
+                    deepEquality = true;
+                }
+                else
+                {
+                    throw new ParserException(
+                        $"Expected '->' or '=>', found '{CurrentToken.Value}'.",
+                        (CurrentToken.Line, CurrentToken.Column)
+                    );
+                }
+
+                AstNode valueArm;
+                if (CurrentToken.Type == TokenType.Throw)
+                {
+                    valueArm = ThrowStatement();
+                }
+                else
+                {
+                    valueArm = AssignmentExpression();
+                }
+
+                arms.Add(new ByArmNode(selector, valueArm, deepEquality) { Line = armLine, Column = armCol });
+            }
+
+            if (CurrentToken.Type == TokenType.RBrace)
+            {
+                break;
+            }
+
+            Match(Token.Comma);
         }
+
+        Match(Token.RBrace);
+
+        return new ByExpression(qualifier, arms, elseArm) { Line = line, Column = col };
     }
 }

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.MultiplicativeExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.MultiplicativeExpression.cs
@@ -16,7 +16,7 @@ namespace EVIL.Grammar.Parsing
 
         private Expression MultiplicativeExpression()
         {
-            var node = ByExpression();
+            var node = PatternExpression();
             var token = CurrentToken;
 
             while (_multiplicativeOperators.Contains(token.Type))
@@ -25,21 +25,21 @@ namespace EVIL.Grammar.Parsing
                 {
                     var (line, col) = Match(Token.Multiply);
 
-                    node = new BinaryExpression(node, PrefixExpression(), BinaryOperationType.Multiply)
+                    node = new BinaryExpression(node, PatternExpression(), BinaryOperationType.Multiply)
                         { Line = line, Column = col };
                 }
                 else if (token.Type == TokenType.Divide)
                 {
                     var (line, col) = Match(Token.Divide);
 
-                    node = new BinaryExpression(node, PrefixExpression(), BinaryOperationType.Divide)
+                    node = new BinaryExpression(node, PatternExpression(), BinaryOperationType.Divide)
                         { Line = line, Column = col };
                 }
                 else if (token.Type == TokenType.Modulo)
                 {
                     var (line, col) = Match(Token.Modulo);
 
-                    node = new BinaryExpression(node, PrefixExpression(), BinaryOperationType.Modulo)
+                    node = new BinaryExpression(node, PatternExpression(), BinaryOperationType.Modulo)
                         { Line = line, Column = col };
                 }
 

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.PatternExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.PatternExpression.cs
@@ -1,0 +1,29 @@
+using EVIL.Grammar.AST.Base;
+using EVIL.Lexical;
+
+namespace EVIL.Grammar.Parsing
+{
+    public partial class Parser
+    {
+        private Expression PatternExpression()
+        {
+            if (CurrentToken.Type == TokenType.By)
+            {
+                return ByExpression();
+            }
+            else
+            {
+                var node = PrefixExpression();
+                var token = CurrentToken;
+
+                while (token.Type == TokenType.With)
+                {
+                    node = WithExpression(node);
+                    token = CurrentToken;
+                }
+
+                return node;
+            }
+        }
+    }
+}

--- a/Core/EVIL.Grammar/Parsing/Expressions/Parser.WithExpression.cs
+++ b/Core/EVIL.Grammar/Parsing/Expressions/Parser.WithExpression.cs
@@ -1,0 +1,26 @@
+﻿namespace EVIL.Grammar.Parsing;
+
+using EVIL.Grammar.AST.Base;
+using EVIL.Grammar.AST.Expressions;
+using EVIL.Lexical;
+
+public partial class Parser
+{
+    private WithExpression WithExpression(Expression left)
+    {
+        var (line, col) = Match(Token.With);
+
+        var tableExpansion = TableExpression();
+
+        if (!tableExpansion.Keyed)
+        {
+            throw new ParserException(
+                "Table expansion expression must be a keyed table.",
+                (tableExpansion.Line, tableExpansion.Column)
+            );
+        }
+
+        return new WithExpression(left, tableExpansion)
+            { Line = line, Column = col };
+    }
+}

--- a/Core/EVIL.Grammar/Traversal/AstVisitor.cs
+++ b/Core/EVIL.Grammar/Traversal/AstVisitor.cs
@@ -67,8 +67,9 @@ namespace EVIL.Grammar.Traversal
                 { typeof(ExpressionBodyStatement), (n) => Visit((ExpressionBodyStatement)n) },
                 { typeof(ExtraArgumentsExpression), (n) => Visit((ExtraArgumentsExpression)n) },
                 { typeof(FnExpression), (n) => Visit((FnExpression)n) },
-                { typeof(IsExpression), (n) => Visit((IsExpression)n)},
-                { typeof(ByExpression), (n) => Visit((ByExpression)n) }
+                { typeof(IsExpression), (n) => Visit((IsExpression)n) },
+                { typeof(ByExpression), (n) => Visit((ByExpression)n) },
+                { typeof(WithExpression), (n) => Visit((WithExpression)n) }
             };
 #nullable enable
         }
@@ -138,5 +139,6 @@ namespace EVIL.Grammar.Traversal
         public abstract void Visit(FnExpression fnExpression);
         public abstract void Visit(IsExpression isExpression);
         public abstract void Visit(ByExpression byExpression);
+        public abstract void Visit(WithExpression withExpression);
     }
 }

--- a/Core/EVIL.Lexical/EVIL.Lexical.csproj
+++ b/Core/EVIL.Lexical/EVIL.Lexical.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>net7.0</TargetFramework>
         <Nullable>enable</Nullable>
         
-        <Version>4.2.0</Version>
+        <Version>4.3.0</Version>
         
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Core/EVIL.Lexical/Lexer.cs
+++ b/Core/EVIL.Lexical/Lexer.cs
@@ -479,6 +479,7 @@ namespace EVIL.Lexical
                 "self" => Token.Self,
                 "error" => Token.Error,
                 "retry" => Token.Retry,
+                "with" => Token.With,
                 "Infinity" => Token.Infinity,
                 "NaN" => Token.NaN,
                 "Nil" => Token.NilTypeCode,

--- a/Core/EVIL.Lexical/Token.cs
+++ b/Core/EVIL.Lexical/Token.cs
@@ -119,6 +119,7 @@ namespace EVIL.Lexical
         public static readonly Token Catch = new(TokenType.Catch, TokenClass.Keyword, "catch");
         public static readonly Token Throw = new(TokenType.Throw, TokenClass.Keyword, "throw");
         public static readonly Token Retry = new(TokenType.Retry, TokenClass.Keyword, "retry");
+        public static readonly Token With = new(TokenType.With, TokenClass.Keyword, "with");
         
         public static readonly Token Val = new(TokenType.Val, TokenClass.Keyword, "val");
         public static readonly Token If = new(TokenType.If, TokenClass.Keyword, "if");

--- a/Core/EVIL.Lexical/TokenType.cs
+++ b/Core/EVIL.Lexical/TokenType.cs
@@ -105,6 +105,7 @@
         Throw,
         Retry,
         Yield,
+        With,
         Rw,
         NaN,
         Infinity,

--- a/Core/Tests/EVIL.CoreTests/LexerTests.cs
+++ b/Core/Tests/EVIL.CoreTests/LexerTests.cs
@@ -76,7 +76,7 @@ namespace EVIL.CoreTests
                 "... => -> -- ++ && || ! " +
                 "<==> <!=> == != > < >= <= " +
                 "# $ @ ? : ; , . { } [ ] ( ) #[ " +
-                "array self"
+                "array self with"
             );
             
             Expect(
@@ -106,7 +106,7 @@ namespace EVIL.CoreTests
                 RParenthesis, AttributeList
             );
 
-            Expect(Token.Array, Self);
+            Expect(Token.Array, Self, With);
 
             Expect(EOF);
         }

--- a/VirtualMachine/EVIL.Ceres/EVIL.Ceres.csproj
+++ b/VirtualMachine/EVIL.Ceres/EVIL.Ceres.csproj
@@ -181,5 +181,8 @@
     <Compile Update="TranslationEngine\Compiler.List.Attribute.cs">
       <DependentUpon>Compiler.cs</DependentUpon>
     </Compile>
+    <Compile Update="TranslationEngine\Compiler.Expression.With.cs">
+      <DependentUpon>Compiler.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/VirtualMachine/EVIL.Ceres/EVIL.Ceres.csproj
+++ b/VirtualMachine/EVIL.Ceres/EVIL.Ceres.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     
-    <Version>7.8.0</Version>
+    <Version>7.9.0</Version>
     
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/VirtualMachine/EVIL.Ceres/ExecutionEngine/Diagnostics/CodeGenerator.cs
+++ b/VirtualMachine/EVIL.Ceres/ExecutionEngine/Diagnostics/CodeGenerator.cs
@@ -93,6 +93,12 @@ namespace EVIL.Ceres.ExecutionEngine
             Emit(value);
             Emit(operand);
         }
+
+        public void Emit(OpCode value, bool operand)
+        {
+            Emit(value);
+            Emit(operand);
+        }
         
         public void Emit(double value)
             => _writer.Write(value);

--- a/VirtualMachine/EVIL.Ceres/ExecutionEngine/Diagnostics/Disassembler.cs
+++ b/VirtualMachine/EVIL.Ceres/ExecutionEngine/Diagnostics/Disassembler.cs
@@ -187,6 +187,16 @@ namespace EVIL.Ceres.ExecutionEngine.Diagnostics
                             output.WriteLine();
                             break;
                         }
+                        
+                        case OpCode.TABCLN:
+                            output.Write(opCode);
+                            output.Write(" ");
+
+                            var isDeepClone = reader.ReadByte();
+                            output.Write(isDeepClone);
+                            
+                            output.WriteLine();
+                            break;
 
                         case OpCode.SETLOCAL:
                         case OpCode.GETLOCAL:

--- a/VirtualMachine/EVIL.Ceres/ExecutionEngine/Diagnostics/OpCode.cs
+++ b/VirtualMachine/EVIL.Ceres/ExecutionEngine/Diagnostics/OpCode.cs
@@ -63,6 +63,7 @@ namespace EVIL.Ceres.ExecutionEngine.Diagnostics
         ELINIT,
         ELSET,
         INDEX,
+        TABCLN,
         YIELD,
         YRET,
         XARGS,

--- a/VirtualMachine/EVIL.Ceres/ExecutionEngine/ExecutionUnit.cs
+++ b/VirtualMachine/EVIL.Ceres/ExecutionEngine/ExecutionUnit.cs
@@ -1345,6 +1345,27 @@ namespace EVIL.Ceres.ExecutionEngine
                     break;
                 }
 
+                case OpCode.TABCLN:
+                {
+                    var isDeepClone = frame.FetchByte() > 0;
+                    a = PopValue();
+
+                    if (a.Type != DynamicValueType.Table)
+                    {
+                        throw new UnsupportedDynamicValueOperationException(
+                            $"Attempt to clone a {a.Type} value."
+                        );
+                    }
+                    
+                    PushValue(
+                        isDeepClone
+                        ? a.Table!.DeepCopy()
+                        : a.Table!.ShallowCopy()
+                    );
+                    
+                    break;
+                }
+
                 case OpCode.YIELD:
                 {
                     var argumentCount = frame.FetchInt32();

--- a/VirtualMachine/EVIL.Ceres/TranslationEngine/Compiler.Expression.With.cs
+++ b/VirtualMachine/EVIL.Ceres/TranslationEngine/Compiler.Expression.With.cs
@@ -1,0 +1,37 @@
+﻿namespace EVIL.Ceres.TranslationEngine;
+
+using EVIL.Ceres.ExecutionEngine.Diagnostics;
+using EVIL.Ceres.TranslationEngine.Diagnostics;
+using EVIL.Grammar.AST.Expressions;
+
+public partial class Compiler
+{
+    public override void Visit(WithExpression withExpression)
+    {
+        Visit(withExpression.BaseExpression);
+        Chunk.CodeGenerator.Emit(OpCode.TABCLN, /* isDeepCopy: */ false);
+
+        if (!withExpression.TableExpansionExpression.Keyed)
+        {
+            Log.TerminateWithFatal(
+                "Expected a keyed expansion table.",
+                CurrentFileName,
+                EvilMessageCode.KeyedExpansionTableExpected,
+                withExpression.TableExpansionExpression.Line,
+                withExpression.TableExpansionExpression.Column
+            );
+
+            return;
+        }
+
+        var initializers = withExpression.TableExpansionExpression.Initializers;
+        for (var i = 0; i < initializers.Count; i++)
+        {
+            var kvp = (KeyValuePairExpression)initializers[i];
+
+            Visit(kvp.ValueNode);
+            Visit(kvp.KeyNode);
+            Chunk.CodeGenerator.Emit(OpCode.ELINIT);
+        }
+    }
+}

--- a/VirtualMachine/EVIL.Ceres/TranslationEngine/Diagnostics/EvilMessageCode.cs
+++ b/VirtualMachine/EVIL.Ceres/TranslationEngine/Diagnostics/EvilMessageCode.cs
@@ -20,5 +20,6 @@
         public const int FnTargetedStatementRedefinedExistingChunk = 0016;
         public const int UnexpectedSyntaxNodeFound = 0017;
         public const int FnIndexedStatementRedefinedExistingChunk = 0018;
+        public const int KeyedExpansionTableExpected = 0019;
     }
 }

--- a/VirtualMachine/Tests/EVIL.Ceres.LanguageTests/EVIL.Ceres.LanguageTests.csproj
+++ b/VirtualMachine/Tests/EVIL.Ceres.LanguageTests/EVIL.Ceres.LanguageTests.csproj
@@ -115,6 +115,9 @@
     <None Update="tests\025_fn_indexed.vil">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="tests\026_with_expr.vil">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/VirtualMachine/Tests/EVIL.Ceres.LanguageTests/Program.cs
+++ b/VirtualMachine/Tests/EVIL.Ceres.LanguageTests/Program.cs
@@ -16,6 +16,7 @@ for (var i = argList.Count - 1; i >= 0; i--)
     switch (argList[i])
     {
         case "--fail-on-compiler-errors":
+        case "-fc":
         {
             failOnCompilerErrors = true;
             argList.RemoveAt(i);
@@ -23,6 +24,7 @@ for (var i = argList.Count - 1; i >= 0; i--)
         }
 
         case "--fail-on-test-errors":
+        case "-ft":
         {
             failOnTestErrors = true;
             argList.RemoveAt(i);

--- a/VirtualMachine/Tests/EVIL.Ceres.LanguageTests/tests/026_with_expr.vil
+++ b/VirtualMachine/Tests/EVIL.Ceres.LanguageTests/tests/026_with_expr.vil
@@ -1,0 +1,50 @@
+﻿#[test]
+fn simple_table_expansion_by_varref {
+  val t = { hello: "world" };
+  val t2 = t with { new: "value!" };
+  
+  assert(t is Table);
+  assert.equal(t.hello, "world");
+  assert.equal(t.new, nil);
+  
+  assert(t2 is Table);
+  assert.equal(t2.hello, "world");
+  assert.equal(t2.new, "value!");
+}
+
+#[test]
+fn dual_table_expansion {
+  val t = { a: 21.37 } with { b: "haha" };
+  
+  assert(t is Table);
+  assert.approx_equal(t.a, 21.37);
+  assert.equal(t.b, "haha");
+}
+
+#[test]
+fn multiple_table_expansion {
+  val t = { a: 11.11 } 
+     with { b: "lmao" } 
+     with { c: "i see absolutely no way in which this can be abused." }
+     with { d: "nuh-uh" };
+     
+  assert(t is Table);
+  assert.approx_equal(t.a, 11.11);
+  assert.equal(t.b, "lmao");
+  assert.equal(t.c, "i see absolutely no way in which this can be abused.");
+  assert.equal(t.d, "nuh-uh");
+}
+
+#[test]
+fn table_value_replacement {
+  val t = { i_am: Table, some: "value, too" };
+  val t2 = t with { i_am: "a string" };
+  
+  assert(t is Table);
+  assert.equal(t.i_am, Table);
+  assert.equal(t.some, "value, too");
+  
+  assert(t2 is Table);
+  assert.equal(t2.i_am, "a string");
+  assert.equal(t2.some, "value, too");
+}


### PR DESCRIPTION
Adds:
- `with` operator keyword allowing language-supported table combination, e.g:
  ```evil
    val a = { some_key: "some_value" };
    val b = a with { some_other_key: 1234 };
  ```
  Then, b will contain both `some_key` and `some_other_key`.
- `OpCode.TABCLN` virtual machine opcode supporting table cloning - either deep or shallow. deep cloning is not used at the moment.
- associated feature tests.